### PR TITLE
Inflate table cleanup

### DIFF
--- a/src/inflate/inftrees.rs
+++ b/src/inflate/inftrees.rs
@@ -116,23 +116,17 @@ pub(crate) fn inflate_table(
 
     // offsets in table for each length
     let mut offs = [0u16; MAX_BITS + 1];
-    let mut len = 1;
-    while len < MAX_BITS {
+    for len in 1..MAX_BITS {
         offs[len + 1] = offs[len] + count[len];
-        len += 1;
     }
 
     /* sort symbols by length, by symbol order within each length */
-    let mut sym = 0;
-    while sym < codes {
-        if lens[sym] != 0 {
-            work[{
-                let tmp = offs[lens[sym] as usize];
-                offs[lens[sym] as usize] += 1;
-                tmp as usize
-            }] = sym as u16;
+    for (sym, len) in lens[0..codes].iter().copied().enumerate() {
+        if len != 0 {
+            let offset = offs[len as usize];
+            offs[len as usize] += 1;
+            work[offset as usize] = sym as u16;
         }
-        sym += 1;
     }
 
     let (base, extra, match_) = match codetype {

--- a/src/inflate/inftrees.rs
+++ b/src/inflate/inftrees.rs
@@ -70,10 +70,8 @@ pub(crate) fn inflate_table(
     // number of codes of each length
     let mut count = [0u16; MAX_BITS + 1];
 
-    let mut sym = 0;
-    while sym < codes {
-        count[lens[sym] as usize] += 1;
-        sym += 1;
+    for len in lens[0..codes].iter().copied() {
+        count[len as usize] += 1;
     }
 
     let mut root = bits;
@@ -189,16 +187,11 @@ pub(crate) fn inflate_table(
 
         // replicate for those indices with low len bits equal to huff
         let incr = 1 << (len - drop_);
-        let mut fill = 1 << curr;
+        let min = 1 << curr; // also has the name 'fill' in the C code
 
-        let min = fill as usize;
-        loop {
-            fill -= incr;
-            table[next..][((huff >> drop_) as i32 + fill) as usize] = here;
-
-            if fill == 0 {
-                break;
-            }
+        let base = &mut table[next + (huff >> drop_)..];
+        for fill in (0..min).step_by(incr) {
+            base[fill] = here;
         }
 
         // backwards increment the len-bit code huff


### PR DESCRIPTION
cleaner and marginally faster (as in, fewer instructions, runtime is not really noticeable). 