### PR TITLE
`ReadBuf`: clean up SIMD code

### DIFF
--- a/zlib-rs/src/inflate.rs
+++ b/zlib-rs/src/inflate.rs
@@ -1237,11 +1237,7 @@ fn inflate_fast_help(state: &mut State, _start: usize) -> ReturnCode {
 
                             // may need some bytes from the output
                             if op < len as usize {
-                                let len = len as usize - op;
-
-                                writer.copy_match(dist as usize, len);
-                            } else {
-                                // nothing?
+                                writer.copy_match(dist as usize, len as usize - op);
                             }
                         } else if extra_safe {
                             todo!()

--- a/zlib-rs/src/read_buf.rs
+++ b/zlib-rs/src/read_buf.rs
@@ -331,6 +331,11 @@ impl<'a> ReadBuf<'a> {
         let start = current.checked_sub(offset_from_end).expect("in bounds");
         let end = start.checked_add(length).expect("in bounds");
 
+        // Note also that the referenced string may overlap the current
+        // position; for example, if the last 2 bytes decoded have values
+        // X and Y, a string reference with <length = 5, distance = 2>
+        // adds X,Y,X,Y,X to the output stream.
+
         if end > current {
             if offset_from_end == 1 {
                 // this will just repeat this value many times


### PR DESCRIPTION
in practice we need less because we can use the rust standard library for most copies. Custom simd is only useful when we know that we can read/write extra bytes without UB (because we made sure the allocate some extra space).