### PR TITLE
fix compilation on aarch64

### DIFF
--- a/fuzz/fuzz_targets/end_to_end.rs
+++ b/fuzz/fuzz_targets/end_to_end.rs
@@ -207,7 +207,7 @@ fn uncompress_slice_ng<'a>(
         libz_ng_sys::inflateInit2_(
             &mut stream,
             config.window_bits,
-            b"1.3.0\0".as_ptr() as *const i8,
+            b"1.3.0\0".as_ptr() as *const std::ffi::c_char,
             std::mem::size_of::<libz_ng_sys::z_stream>() as i32,
         )
     };

--- a/fuzz/fuzz_targets/inflate_chunked.rs
+++ b/fuzz/fuzz_targets/inflate_chunked.rs
@@ -40,7 +40,7 @@ fn deflate_ng(data: &[u8], window_bits: i32) -> Vec<u8> {
             window_bits as i32,
             mem_level,
             strategy,
-            b"1.3.0\0".as_ptr() as *const i8,
+            b"1.3.0\0".as_ptr() as *const std::ffi::c_char,
             std::mem::size_of::<libz_ng_sys::z_stream>() as i32,
         );
         let return_code = ReturnCode::from(err);

--- a/libz-rs-sys/src/tests/inflate.rs
+++ b/libz-rs-sys/src/tests/inflate.rs
@@ -936,7 +936,7 @@ fn small_window_ours() {
             -9,
             8,
             libz_ng_sys::Z_DEFAULT_STRATEGY,
-            b"1.3.0\0".as_ptr() as *const i8,
+            b"1.3.0\0".as_ptr() as *const std::ffi::c_char,
             std::mem::size_of::<libz_ng_sys::z_stream>() as i32,
         );
 

--- a/zlib-rs/src/adler32.rs
+++ b/zlib-rs/src/adler32.rs
@@ -179,6 +179,7 @@ fn adler32_len_64(mut adler: u32, buf: &[u8], mut sum2: u32) -> u32 {
     adler32_len_16(adler, it.remainder(), sum2)
 }
 
+#[cfg(target_arch = "x86_64")]
 mod avx2 {
     use super::*;
 

--- a/zlib-rs/src/adler32.rs
+++ b/zlib-rs/src/adler32.rs
@@ -145,7 +145,7 @@ fn adler32_len_16(mut adler: u32, buf: &[u8], mut sum2: u32) -> u32 {
     adler | (sum2 << 16)
 }
 
-#[cfg_attr(not(target_arch = "x86_64"), unused)]
+#[cfg_attr(not(target_arch = "x86_64"), allow(unused))]
 fn adler32_copy_len_16(
     mut adler: u32,
     dst: &mut [MaybeUninit<u8>],

--- a/zlib-rs/src/adler32.rs
+++ b/zlib-rs/src/adler32.rs
@@ -145,6 +145,7 @@ fn adler32_len_16(mut adler: u32, buf: &[u8], mut sum2: u32) -> u32 {
     adler | (sum2 << 16)
 }
 
+#[cfg_attr(not(target_arch = "x86_64"), unused)]
 fn adler32_copy_len_16(
     mut adler: u32,
     dst: &mut [MaybeUninit<u8>],

--- a/zlib-rs/src/crc32.rs
+++ b/zlib-rs/src/crc32.rs
@@ -1,6 +1,7 @@
 use crate::CRC32_INITIAL_VALUE;
 
 mod braid;
+#[cfg(target_arch = "x86_64")]
 mod pclmulqdq;
 
 pub fn crc32(buf: &[u8], start: u32) -> u32 {

--- a/zlib-rs/src/crc32.rs
+++ b/zlib-rs/src/crc32.rs
@@ -93,72 +93,75 @@ impl Crc32Fold {
     }
 }
 
-/// CRC32 single round checksum for bytes (8 bits).
-///
-/// [Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/__crc32b)
-#[cfg(target_arch = "arm")]
-#[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
-fn __crc32b(h: u32, val: u8) -> u32 {
-    let mut out = 0u32;
-    unsafe {
-        std::arch::asm!("crc32b {wd:w}, {wn:w}, {wm:w}",
-        wn = in(reg) h,
-        wm = in(reg) val,
-        wd = out(reg) out,
-        )
+#[cfg(any(target_arch = "aarch64", target_arch = "arm"))]
+pub mod arm {
+    /// CRC32 single round checksum for bytes (8 bits).
+    ///
+    /// [Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/__crc32b)
+    #[target_feature(enable = "crc")]
+    #[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
+    pub unsafe fn __crc32b(h: u32, val: u8) -> u32 {
+        let mut out;
+        unsafe {
+            std::arch::asm!("crc32b {wd:w}, {wn:w}, {wm:w}",
+            wn = in(reg) h,
+            wm = in(reg) val,
+            wd = out(reg) out,
+            )
+        }
+        out
     }
-    out
-}
 
-/// CRC32 single round checksum for half words (16 bits).
-///
-/// [Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/__crc32h)
-#[cfg(target_arch = "arm")]
-#[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
-fn __crc32h(h: u32, val: u16) -> u32 {
-    let mut out = 0u32;
-    unsafe {
-        std::arch::asm!("crc32h {wd:w}, {wn:w}, {wm:w}",
-        wn = in(reg) h,
-        wm = in(reg) val,
-        wd = out(reg) out,
-        )
+    /// CRC32 single round checksum for half words (16 bits).
+    ///
+    /// [Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/__crc32h)
+    #[target_feature(enable = "crc")]
+    #[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
+    pub unsafe fn __crc32h(h: u32, val: u16) -> u32 {
+        let mut out;
+        unsafe {
+            std::arch::asm!("crc32h {wd:w}, {wn:w}, {wm:w}",
+            wn = in(reg) h,
+            wm = in(reg) val,
+            wd = out(reg) out,
+            )
+        }
+        out
     }
-    out
-}
 
-/// CRC32 single round checksum for words (32 bits).
-///
-/// [Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/__crc32w)
-#[cfg(target_arch = "arm")]
-#[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
-fn __crc32w(h: u32, val: u32) -> u32 {
-    let mut out = 0u32;
-    unsafe {
-        std::arch::asm!("crc32w {wd:w}, {wn:w}, {wm:w}",
-        wn = in(reg) h,
-        wm = in(reg) val,
-        wd = out(reg) out,
-        )
+    /// CRC32 single round checksum for words (32 bits).
+    ///
+    /// [Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/__crc32w)
+    #[target_feature(enable = "crc")]
+    #[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
+    pub unsafe fn __crc32w(h: u32, val: u32) -> u32 {
+        let mut out;
+        unsafe {
+            std::arch::asm!("crc32w {wd:w}, {wn:w}, {wm:w}",
+            wn = in(reg) h,
+            wm = in(reg) val,
+            wd = out(reg) out,
+            )
+        }
+        out
     }
-    out
-}
 
-/// CRC32-C single round checksum for words (32 bits).
-///
-/// [Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/__crc32cw)
-#[cfg(target_arch = "arm")]
-#[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
-pub fn __crc32cw(crc: u32, data: u32) -> u32 {
-    let mut out = 0u32;
-    unsafe {
-        std::arch::asm!("crc32cw {wd:w}, {wn:w}, {wm:w}",
-        wn = in(reg) crc,
-        wm = in(reg) data,
-        wd = out(reg) out,
-        )
+    /// CRC32-C single round checksum for words (32 bits).
+    ///
+    /// [Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/__crc32cw)
+    #[target_feature(enable = "crc")]
+    #[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
+    pub unsafe fn __crc32cw(crc: u32, data: u32) -> u32 {
+        let mut out;
+        unsafe {
+            std::arch::asm!("crc32cw {wd:w}, {wn:w}, {wm:w}",
+            wn = in(reg) crc,
+            wm = in(reg) data,
+            wd = out(reg) out,
+            )
+        }
+        out
     }
-    out
 }
 
 #[cfg(test)]
@@ -238,32 +241,40 @@ mod test {
         }
     }
 
-    #[cfg(target_arch = "arm")]
+    #[cfg(target_arch = "aarch64")]
     mod arm_crc32_asm {
-        use super::*;
+        use super::arm::*;
 
         #[test]
-        unsafe fn test_crc32b() {
-            assert_eq!(__crc32b(0, 0), 0);
-            assert_eq!(__crc32b(0, 255), 755167117);
+        fn test_crc32b() {
+            unsafe {
+                assert_eq!(__crc32b(0, 0), 0);
+                assert_eq!(__crc32b(0, 255), 755167117);
+            }
         }
 
         #[test]
-        unsafe fn test_crc32h() {
-            assert_eq!(__crc32h(0, 0), 0);
-            assert_eq!(__crc32h(0, 16384), 1994146192);
+        fn test_crc32h() {
+            unsafe {
+                assert_eq!(__crc32h(0, 0), 0);
+                assert_eq!(__crc32h(0, 16384), 1994146192);
+            }
         }
 
         #[test]
-        unsafe fn test_crc32w() {
-            assert_eq!(__crc32w(0, 0), 0);
-            assert_eq!(__crc32w(0, 4294967295), 3736805603);
+        fn test_crc32w() {
+            unsafe {
+                assert_eq!(__crc32w(0, 0), 0);
+                assert_eq!(__crc32w(0, 4294967295), 3736805603);
+            }
         }
 
         #[test]
-        unsafe fn test_crc32cw() {
-            assert_eq!(__crc32cw(0, 0), 0);
-            assert_eq!(__crc32cw(0, 4294967295), 3080238136);
+        fn test_crc32cw() {
+            unsafe {
+                assert_eq!(__crc32cw(0, 0), 0);
+                assert_eq!(__crc32cw(0, 4294967295), 3080238136);
+            }
         }
     }
 }

--- a/zlib-rs/src/crc32.rs
+++ b/zlib-rs/src/crc32.rs
@@ -63,10 +63,10 @@ impl Crc32Fold {
             && is_x86_feature_detected!("sse4.1")
     }
 
-    pub fn fold(&mut self, src: &[u8], start: u32) {
+    pub fn fold(&mut self, src: &[u8], _start: u32) {
         #[cfg(target_arch = "x86_64")]
         if Self::is_pclmulqdq() {
-            return self.fold.fold(src, start);
+            return self.fold.fold(src, _start);
         }
 
         // in this case the start value is ignored

--- a/zlib-rs/src/crc32.rs
+++ b/zlib-rs/src/crc32.rs
@@ -93,6 +93,74 @@ impl Crc32Fold {
     }
 }
 
+/// CRC32 single round checksum for bytes (8 bits).
+///
+/// [Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/__crc32b)
+#[cfg(target_arch = "arm")]
+#[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
+fn __crc32b(h: u32, val: u8) -> u32 {
+    let mut out = 0u32;
+    unsafe {
+        std::arch::asm!("crc32b {wd:w}, {wn:w}, {wm:w}",
+        wn = in(reg) h,
+        wm = in(reg) val,
+        wd = out(reg) out,
+        )
+    }
+    out
+}
+
+/// CRC32 single round checksum for half words (16 bits).
+///
+/// [Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/__crc32h)
+#[cfg(target_arch = "arm")]
+#[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
+fn __crc32h(h: u32, val: u16) -> u32 {
+    let mut out = 0u32;
+    unsafe {
+        std::arch::asm!("crc32h {wd:w}, {wn:w}, {wm:w}",
+        wn = in(reg) h,
+        wm = in(reg) val,
+        wd = out(reg) out,
+        )
+    }
+    out
+}
+
+/// CRC32 single round checksum for words (32 bits).
+///
+/// [Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/__crc32w)
+#[cfg(target_arch = "arm")]
+#[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
+fn __crc32w(h: u32, val: u32) -> u32 {
+    let mut out = 0u32;
+    unsafe {
+        std::arch::asm!("crc32w {wd:w}, {wn:w}, {wm:w}",
+        wn = in(reg) h,
+        wm = in(reg) val,
+        wd = out(reg) out,
+        )
+    }
+    out
+}
+
+/// CRC32-C single round checksum for words (32 bits).
+///
+/// [Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/__crc32cw)
+#[cfg(target_arch = "arm")]
+#[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
+pub fn __crc32cw(crc: u32, data: u32) -> u32 {
+    let mut out = 0u32;
+    unsafe {
+        std::arch::asm!("crc32cw {wd:w}, {wn:w}, {wm:w}",
+        wn = in(reg) crc,
+        wm = in(reg) data,
+        wd = out(reg) out,
+        )
+    }
+    out
+}
+
 #[cfg(test)]
 mod test {
     use super::*;
@@ -167,6 +235,35 @@ mod test {
             assert_eq!(a,b);
 
             v == dst
+        }
+    }
+
+    #[cfg(target_arch = "arm")]
+    mod arm_crc32_asm {
+        use super::*;
+
+        #[test]
+        unsafe fn test_crc32b() {
+            assert_eq!(__crc32b(0, 0), 0);
+            assert_eq!(__crc32b(0, 255), 755167117);
+        }
+
+        #[test]
+        unsafe fn test_crc32h() {
+            assert_eq!(__crc32h(0, 0), 0);
+            assert_eq!(__crc32h(0, 16384), 1994146192);
+        }
+
+        #[test]
+        unsafe fn test_crc32w() {
+            assert_eq!(__crc32w(0, 0), 0);
+            assert_eq!(__crc32w(0, 4294967295), 3736805603);
+        }
+
+        #[test]
+        unsafe fn test_crc32cw() {
+            assert_eq!(__crc32cw(0, 0), 0);
+            assert_eq!(__crc32cw(0, 4294967295), 3080238136);
         }
     }
 }

--- a/zlib-rs/src/deflate.rs
+++ b/zlib-rs/src/deflate.rs
@@ -422,11 +422,14 @@ fn lm_set_level(state: &mut State, level: i8) {
         state.update_hash = RollHashCalc::update_hash;
         state.insert_string = RollHashCalc::insert_string;
         state.quick_insert_string = RollHashCalc::quick_insert_string;
-    } else {
-        // NOTE: this is hardcoded currently
+    } else if Crc32HashCalc::is_supported() {
         state.update_hash = Crc32HashCalc::update_hash;
         state.insert_string = Crc32HashCalc::insert_string;
         state.quick_insert_string = Crc32HashCalc::quick_insert_string;
+    } else {
+        state.update_hash = StandardHashCalc::update_hash;
+        state.insert_string = StandardHashCalc::insert_string;
+        state.quick_insert_string = StandardHashCalc::quick_insert_string;
     }
 
     state.level = level;

--- a/zlib-rs/src/deflate.rs
+++ b/zlib-rs/src/deflate.rs
@@ -2823,4 +2823,12 @@ mod test {
             &[],
         )
     }
+
+    quickcheck::quickcheck! {
+        fn rs_is_ng(bytes: Vec<u8>) -> bool {
+            fuzz_based_test(&bytes, DeflateConfig::default(), &[]);
+
+            true
+        }
+    }
 }

--- a/zlib-rs/src/deflate.rs
+++ b/zlib-rs/src/deflate.rs
@@ -995,7 +995,7 @@ enum Status {
     Finish,
 }
 
-const fn error_message(return_code: ReturnCode) -> *const i8 {
+const fn error_message(return_code: ReturnCode) -> *const std::ffi::c_char {
     const TABLE: [&str; 10] = [
         "need dictionary\0",      /* Z_NEED_DICT       2  */
         "stream end\0",           /* Z_STREAM_END      1  */

--- a/zlib-rs/src/deflate/hash_calc.rs
+++ b/zlib-rs/src/deflate/hash_calc.rs
@@ -1,3 +1,5 @@
+use std::arch::is_aarch64_feature_detected;
+
 use crate::deflate::{State, HASH_SIZE, STD_MIN_MATCH};
 
 pub trait HashCalc {
@@ -122,6 +124,20 @@ impl HashCalc for RollHashCalc {
 }
 
 pub struct Crc32HashCalc;
+
+impl Crc32HashCalc {
+    pub const fn is_supported() -> bool {
+        if cfg!(target_arch = "x86") || cfg!(target_arch = "x86_64") {
+            return true;
+        }
+
+        #[cfg(target_arch = "aarch64")]
+        return is_aarch64_feature_detected!("crc");
+
+        #[allow(unreachable_code)]
+        false
+    }
+}
 
 impl HashCalc for Crc32HashCalc {
     const HASH_CALC_OFFSET: usize = 0;

--- a/zlib-rs/src/deflate/hash_calc.rs
+++ b/zlib-rs/src/deflate/hash_calc.rs
@@ -128,6 +128,12 @@ impl HashCalc for Crc32HashCalc {
 
     const HASH_CALC_MASK: u32 = (HASH_SIZE - 1) as u32;
 
+    #[cfg(target_arch = "x86")]
+    fn hash_calc(h: u32, val: u32) -> u32 {
+        unsafe { std::arch::x86::_mm_crc32_u32(h, val) }
+    }
+
+    #[cfg(target_arch = "x86_64")]
     fn hash_calc(h: u32, val: u32) -> u32 {
         unsafe { std::arch::x86_64::_mm_crc32_u32(h, val) }
     }

--- a/zlib-rs/src/deflate/hash_calc.rs
+++ b/zlib-rs/src/deflate/hash_calc.rs
@@ -140,16 +140,7 @@ impl HashCalc for Crc32HashCalc {
 
     #[cfg(target_arch = "aarch64")]
     fn hash_calc(h: u32, val: u32) -> u32 {
-        let mut out = 0u32;
-        unsafe {
-            std::arch::asm!("crc32cw {wd:w}, {wn:w}, {wm:w}",
-            wn = in(reg) h,
-            wm = in(reg) val,
-            wd = out(reg) out,
-            )
-        }
-
-        out
+        crate::crc32::__crc32cw(h, val)
     }
 }
 

--- a/zlib-rs/src/deflate/hash_calc.rs
+++ b/zlib-rs/src/deflate/hash_calc.rs
@@ -137,20 +137,63 @@ impl HashCalc for Crc32HashCalc {
     fn hash_calc(h: u32, val: u32) -> u32 {
         unsafe { std::arch::x86_64::_mm_crc32_u32(h, val) }
     }
+
+    #[cfg(target_arch = "aarch64")]
+    fn hash_calc(h: u32, val: u32) -> u32 {
+        let mut out = 0u32;
+        unsafe {
+            std::arch::asm!("crc32cw {wd:w}, {wn:w}, {wm:w}",
+            wn = in(reg) h,
+            wm = in(reg) val,
+            wd = out(reg) out,
+            )
+        }
+
+        out
+    }
 }
 
-#[test]
-fn roll_hash_calc() {
-    assert_eq!(RollHashCalc::hash_calc(2565, 93), 82173);
-    assert_eq!(RollHashCalc::hash_calc(16637, 10), 532394);
-    assert_eq!(RollHashCalc::hash_calc(8106, 100), 259364);
-    assert_eq!(RollHashCalc::hash_calc(29988, 101), 959717);
-    assert_eq!(RollHashCalc::hash_calc(9445, 98), 302274);
-    assert_eq!(RollHashCalc::hash_calc(7362, 117), 235573);
-    assert_eq!(RollHashCalc::hash_calc(6197, 103), 198343);
-    assert_eq!(RollHashCalc::hash_calc(1735, 32), 55488);
-    assert_eq!(RollHashCalc::hash_calc(22720, 61), 727101);
-    assert_eq!(RollHashCalc::hash_calc(6205, 32), 198528);
-    assert_eq!(RollHashCalc::hash_calc(3826, 117), 122421);
-    assert_eq!(RollHashCalc::hash_calc(24117, 101), 771781);
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn crc32_hash_calc() {
+        assert_eq!(Crc32HashCalc::hash_calc(0, 807411760), 2423125009);
+        assert_eq!(Crc32HashCalc::hash_calc(0, 540024864), 1452438466);
+        assert_eq!(Crc32HashCalc::hash_calc(0, 538980384), 435552201);
+        assert_eq!(Crc32HashCalc::hash_calc(0, 807411760), 2423125009);
+        assert_eq!(Crc32HashCalc::hash_calc(0, 540024864), 1452438466);
+        assert_eq!(Crc32HashCalc::hash_calc(0, 538980384), 435552201);
+        assert_eq!(Crc32HashCalc::hash_calc(0, 807411760), 2423125009);
+        assert_eq!(Crc32HashCalc::hash_calc(0, 540024864), 1452438466);
+        assert_eq!(Crc32HashCalc::hash_calc(0, 538980384), 435552201);
+        assert_eq!(Crc32HashCalc::hash_calc(0, 807411760), 2423125009);
+        assert_eq!(Crc32HashCalc::hash_calc(0, 540024864), 1452438466);
+        assert_eq!(Crc32HashCalc::hash_calc(0, 538980384), 435552201);
+        assert_eq!(Crc32HashCalc::hash_calc(0, 807411760), 2423125009);
+        assert_eq!(Crc32HashCalc::hash_calc(0, 170926112), 500028708);
+        assert_eq!(Crc32HashCalc::hash_calc(0, 537538592), 3694129053);
+        assert_eq!(Crc32HashCalc::hash_calc(0, 538970672), 373925026);
+        assert_eq!(Crc32HashCalc::hash_calc(0, 538976266), 4149335727);
+        assert_eq!(Crc32HashCalc::hash_calc(0, 538976288), 1767342659);
+        assert_eq!(Crc32HashCalc::hash_calc(0, 941629472), 4090502627);
+        assert_eq!(Crc32HashCalc::hash_calc(0, 775430176), 1744703325);
+    }
+
+    #[test]
+    fn roll_hash_calc() {
+        assert_eq!(RollHashCalc::hash_calc(2565, 93), 82173);
+        assert_eq!(RollHashCalc::hash_calc(16637, 10), 532394);
+        assert_eq!(RollHashCalc::hash_calc(8106, 100), 259364);
+        assert_eq!(RollHashCalc::hash_calc(29988, 101), 959717);
+        assert_eq!(RollHashCalc::hash_calc(9445, 98), 302274);
+        assert_eq!(RollHashCalc::hash_calc(7362, 117), 235573);
+        assert_eq!(RollHashCalc::hash_calc(6197, 103), 198343);
+        assert_eq!(RollHashCalc::hash_calc(1735, 32), 55488);
+        assert_eq!(RollHashCalc::hash_calc(22720, 61), 727101);
+        assert_eq!(RollHashCalc::hash_calc(6205, 32), 198528);
+        assert_eq!(RollHashCalc::hash_calc(3826, 117), 122421);
+        assert_eq!(RollHashCalc::hash_calc(24117, 101), 771781);
+    }
 }

--- a/zlib-rs/src/deflate/hash_calc.rs
+++ b/zlib-rs/src/deflate/hash_calc.rs
@@ -1,5 +1,3 @@
-use std::arch::is_aarch64_feature_detected;
-
 use crate::deflate::{State, HASH_SIZE, STD_MIN_MATCH};
 
 pub trait HashCalc {
@@ -132,7 +130,7 @@ impl Crc32HashCalc {
         }
 
         #[cfg(target_arch = "aarch64")]
-        return is_aarch64_feature_detected!("crc");
+        return std::arch::is_aarch64_feature_detected!("crc");
 
         #[allow(unreachable_code)]
         false

--- a/zlib-rs/src/deflate/hash_calc.rs
+++ b/zlib-rs/src/deflate/hash_calc.rs
@@ -126,7 +126,7 @@ impl HashCalc for RollHashCalc {
 pub struct Crc32HashCalc;
 
 impl Crc32HashCalc {
-    pub const fn is_supported() -> bool {
+    pub fn is_supported() -> bool {
         if cfg!(target_arch = "x86") || cfg!(target_arch = "x86_64") {
             return true;
         }
@@ -156,7 +156,7 @@ impl HashCalc for Crc32HashCalc {
 
     #[cfg(target_arch = "aarch64")]
     fn hash_calc(h: u32, val: u32) -> u32 {
-        crate::crc32::__crc32cw(h, val)
+        unsafe { crate::crc32::arm::__crc32cw(h, val) }
     }
 }
 

--- a/zlib-rs/src/dynamic.rs
+++ b/zlib-rs/src/dynamic.rs
@@ -216,7 +216,7 @@ fn compress_slice_dynamic<'a>(
             window_bits,
             mem_level,
             strategy as i32,
-            // b"1.3.0\0".as_ptr() as *const i8,
+            // b"1.3.0\0".as_ptr() as *const std::ffi::c_char,
             // std::mem::size_of::<libz_ng_sys::z_stream>() as i32,
         );
         let return_code = ReturnCode::from(err);

--- a/zlib-rs/src/inflate.rs
+++ b/zlib-rs/src/inflate.rs
@@ -1504,7 +1504,7 @@ pub unsafe fn inflate(stream: &mut InflateStream, flush: Flush) -> ReturnCode {
 
     if let Some(msg) = stream.state.error_message {
         assert!(msg.ends_with(|c| c == '\0'));
-        stream.msg = msg.as_ptr() as *mut u8 as *mut i8;
+        stream.msg = msg.as_ptr() as *mut u8 as *mut std::ffi::c_char;
     }
 
     if ((in_read == 0 && out_written == 0) || flush == Flush::Finish as _)

--- a/zlib-rs/src/read_buf.rs
+++ b/zlib-rs/src/read_buf.rs
@@ -465,6 +465,7 @@ impl Chunk for u64 {
     }
 }
 
+#[cfg(target_arch = "x86_64")]
 impl Chunk for core::arch::x86_64::__m128i {
     #[inline(always)]
     unsafe fn load_chunk(from: *const MaybeUninit<u8>) -> Self {
@@ -477,6 +478,7 @@ impl Chunk for core::arch::x86_64::__m128i {
     }
 }
 
+#[cfg(target_arch = "x86_64")]
 impl Chunk for core::arch::x86_64::__m256i {
     #[inline(always)]
     unsafe fn load_chunk(from: *const MaybeUninit<u8>) -> Self {
@@ -489,6 +491,7 @@ impl Chunk for core::arch::x86_64::__m256i {
     }
 }
 
+#[cfg(target_arch = "x86_64")]
 impl Chunk for core::arch::x86_64::__m512i {
     #[inline(always)]
     unsafe fn load_chunk(from: *const MaybeUninit<u8>) -> Self {


### PR DESCRIPTION
there are 3 test failures, but they are hard to debug because the input is large and they only fail after a large number of bytes. Fuzzing is broken on the raspberry pi https://github.com/google/sanitizers/issues/1674 so there isn' really a good way of narrowing down the issue with our current hardware.