### PR TITLE
move libc dependency one crate up

### DIFF
--- a/libz-rs-sys/Cargo.toml
+++ b/libz-rs-sys/Cargo.toml
@@ -14,12 +14,13 @@ rust-version.workspace = true
 crate-type=["rlib", "cdylib"]
 
 [dependencies]
-zlib-rs = { workspace = true, features = [ "__internal-test" ] }
+zlib-rs = { workspace = true }
+libc.workspace = true
 
 [dev-dependencies]
+zlib-rs = { workspace = true, features = [ "__internal-test" ] }
 libz-ng-sys.workspace = true
 libloading.workspace = true
 load-dynamic-libz-ng.workspace = true
-libc.workspace = true
 crc32fast = "1.3.2"
 quickcheck = "1.0.3"

--- a/libz-rs-sys/src/lib.rs
+++ b/libz-rs-sys/src/lib.rs
@@ -17,6 +17,12 @@ use zlib_rs::{
 
 pub use zlib_rs::c_api::*;
 
+#[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
+pub type z_off_t = libc::off_t;
+
+#[cfg(all(target_family = "wasm", target_os = "unknown"))]
+pub type z_off_t = c_long;
+
 pub unsafe extern "C" fn crc32(crc: c_ulong, buf: *const Bytef, len: uInt) -> c_ulong {
     let buf = unsafe { std::slice::from_raw_parts(buf, len as usize) };
     zlib_rs::crc32(crc as u32, buf) as c_ulong

--- a/zlib-rs/Cargo.toml
+++ b/zlib-rs/Cargo.toml
@@ -21,8 +21,7 @@ __internal-test = ["quickcheck"]
 [dependencies]
 arbitrary = { workspace = true, optional = true, features = ["derive"] }
 libz-ng-sys = { workspace = true, optional = true }
-libc.workspace = true
-quickcheck = { version = "1.0.3", optional = true }
+quickcheck = { version = "1.0.3", optional = true, default-features = false, features = [] }
 
 [dev-dependencies]
 libloading = "0.8.1"

--- a/zlib-rs/src/c_api.rs
+++ b/zlib-rs/src/c_api.rs
@@ -79,12 +79,6 @@ impl z_stream {
 pub(crate) type z_size = c_ulong;
 pub(crate) type z_checksum = c_ulong;
 
-#[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
-pub type z_off_t = libc::off_t;
-
-#[cfg(all(target_family = "wasm", target_os = "unknown"))]
-pub type z_off_t = c_long;
-
 // opaque to the user
 pub enum internal_state {}
 

--- a/zlib-rs/src/deflate.rs
+++ b/zlib-rs/src/deflate.rs
@@ -33,10 +33,10 @@ pub struct DeflateStream<'a> {
     pub(crate) next_out: *mut crate::c_api::Bytef,
     pub(crate) avail_out: crate::c_api::uInt,
     pub(crate) total_out: crate::c_api::z_size,
-    pub(crate) msg: *const libc::c_char,
+    pub(crate) msg: *const std::ffi::c_char,
     pub(crate) state: &'a mut State<'a>,
     pub(crate) alloc: Allocator<'a>,
-    pub(crate) data_type: libc::c_int,
+    pub(crate) data_type: std::ffi::c_int,
     pub(crate) adler: crate::c_api::z_checksum,
     pub(crate) reserved: crate::c_api::uLong,
 }
@@ -2631,7 +2631,7 @@ pub fn compress<'a>(
         return (&mut [], err);
     }
 
-    let max = libc::c_uint::MAX as usize;
+    let max = core::ffi::c_uint::MAX as usize;
 
     let mut left = output.len();
     let mut source_len = input.len();


### PR DESCRIPTION
zlib-rs is now dependency-free in a release build