### PR TITLE
a better rust allocator

### DIFF
--- a/zlib-rs/src/deflate.rs
+++ b/zlib-rs/src/deflate.rs
@@ -680,7 +680,9 @@ pub fn end<'a>(stream: &'a mut DeflateStream) -> Result<&'a mut z_stream, &'a mu
         stream.state.sym_buf.drop_in(&alloc);
         stream.state.pending.drop_in(&alloc);
         alloc.deallocate(stream.state.head, 1);
-        alloc.deallocate(stream.state.prev.as_mut_ptr(), stream.state.prev.len());
+        if !stream.state.prev.is_empty() {
+            alloc.deallocate(stream.state.prev.as_mut_ptr(), stream.state.prev.len());
+        }
         stream.state.window.drop_in(&alloc);
     }
 

--- a/zlib-rs/src/deflate/window.rs
+++ b/zlib-rs/src/deflate/window.rs
@@ -41,7 +41,7 @@ impl<'a> Window<'a> {
     pub unsafe fn drop_in(&mut self, alloc: &Allocator) {
         if !self.buf.is_empty() {
             let buf = core::mem::take(&mut self.buf);
-            alloc.deallocate(buf.as_mut_ptr(), self.buf.len());
+            alloc.deallocate(buf.as_mut_ptr(), buf.len());
         }
     }
 

--- a/zlib-rs/src/inflate/window.rs
+++ b/zlib-rs/src/inflate/window.rs
@@ -171,7 +171,7 @@ impl<'a> Window<'a> {
     pub unsafe fn drop_in(mut self, alloc: &Allocator) {
         if !self.buf.is_empty() {
             let buf = core::mem::take(&mut self.buf);
-            alloc.deallocate(buf.as_mut_ptr(), self.buf.len());
+            alloc.deallocate(buf.as_mut_ptr(), buf.len());
         }
     }
 

--- a/zlib-rs/src/read_buf.rs
+++ b/zlib-rs/src/read_buf.rs
@@ -424,7 +424,7 @@ impl<'a> ReadBuf<'a> {
     pub(crate) unsafe fn drop_in(&mut self, alloc: &Allocator<'a>) {
         if !self.buf.is_empty() {
             let buf = core::mem::take(&mut self.buf);
-            alloc.deallocate(buf.as_mut_ptr(), self.buf.len());
+            alloc.deallocate(buf.as_mut_ptr(), buf.len());
         }
     }
 }


### PR DESCRIPTION
uses `opaque` and some internal knowledge to pass the size of the allocation to the rust system allocator. Still ensures an alignment of 64 bytes