### PR TITLE
Refactor deflate `BitWriter`

### DIFF
--- a/zlib-rs/src/deflate/algorithm/quick.rs
+++ b/zlib-rs/src/deflate/algorithm/quick.rs
@@ -20,7 +20,7 @@ pub fn deflate_quick(stream: &mut DeflateStream, flush: DeflateFlush) -> BlockSt
 
     macro_rules! quick_start_block {
         () => {
-            state.emit_tree(BlockType::StaticTrees, last);
+            state.bit_writer.emit_tree(BlockType::StaticTrees, last);
             state.block_open = 1 + last as u8;
             state.block_start = state.strstart as isize;
         };
@@ -29,7 +29,9 @@ pub fn deflate_quick(stream: &mut DeflateStream, flush: DeflateFlush) -> BlockSt
     macro_rules! quick_end_block {
         () => {
             if state.block_open > 0 {
-                state.emit_end_block_and_align(&StaticTreeDesc::L.static_tree, last);
+                state
+                    .bit_writer
+                    .emit_end_block_and_align(&StaticTreeDesc::L.static_tree, last);
                 state.block_open = 0;
                 state.block_start = state.strstart as isize;
                 flush_pending(stream);
@@ -121,7 +123,7 @@ pub fn deflate_quick(stream: &mut DeflateStream, flush: DeflateFlush) -> BlockSt
                         // TODO do this with a debug_assert?
                         // check_match(s, state.strstart, hash_head, match_len);
 
-                        state.emit_dist(
+                        state.bit_writer.emit_dist(
                             StaticTreeDesc::L.static_tree,
                             StaticTreeDesc::D.static_tree,
                             (match_len - STD_MIN_MATCH) as u8,
@@ -136,7 +138,7 @@ pub fn deflate_quick(stream: &mut DeflateStream, flush: DeflateFlush) -> BlockSt
         }
 
         let lc = state.window.filled()[state.strstart];
-        state.emit_lit(StaticTreeDesc::L.static_tree, lc);
+        state.bit_writer.emit_lit(StaticTreeDesc::L.static_tree, lc);
         state.strstart += 1;
         state.lookahead -= 1;
     }

--- a/zlib-rs/src/deflate/algorithm/quick.rs
+++ b/zlib-rs/src/deflate/algorithm/quick.rs
@@ -59,7 +59,7 @@ pub fn deflate_quick(stream: &mut DeflateStream, flush: DeflateFlush) -> BlockSt
     }
 
     loop {
-        if state.pending.pending + State::BIT_BUF_SIZE.div_ceil(8) as usize
+        if state.bit_writer.pending.pending + State::BIT_BUF_SIZE.div_ceil(8) as usize
             >= state.pending_buf_size()
         {
             flush_pending(stream);
@@ -67,7 +67,7 @@ pub fn deflate_quick(stream: &mut DeflateStream, flush: DeflateFlush) -> BlockSt
             if stream.avail_out == 0 {
                 return if last
                     && stream.avail_in == 0
-                    && state.bi_valid == 0
+                    && state.bit_writer.bits_used == 0
                     && state.block_open == 0
                 {
                     BlockState::FinishStarted


### PR DESCRIPTION
the goal here is to prevent the cloning or moving of fields, e.g. this pattern

```rust
let mut tmp = Default::default();
std::mem::swap(&mut tmp, &mut state.field);
foobar(&tmp);
std::mem::swap(&mut tmp, &mut state.field);
```

this PR removes this sort of cloning in 2 places.