### PR TITLE
feat: no_std

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,6 @@ libz-sys = { version = "1.1.12", default-features = false, features = ["zlib-ng"
 arbitrary = { version = "1.0" }
 quickcheck = { version = "1.0.3", default-features = false, features = [] }
 
-zlib-rs = { version = "0.1.1", path = "./zlib-rs" }
+zlib-rs = { version = "0.1.1", path = "./zlib-rs", default-features = false }
 load-dynamic-libz-ng = { path = "./load-dynamic-libz-ng" }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ homepage = "https://github.com/memorysafety/zlib-rs"
 readme = "./README.md"
 description = "A memory-safe zlib implementation written in rust"
 publish = true
-rust-version = "1.70" # MSRV
+rust-version = "1.73" # MSRV
 
 [profile.release]
 debug = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ opt-level = 1 # required for the tail calls in inflate to optimize
 libloading = "0.8.1"
 libz-sys = { version = "1.1.12", default-features = false, features = ["zlib-ng"] } # use libz-ng in libz compat mode
 arbitrary = { version = "1.0" }
+quickcheck = { version = "1.0.3", default-features = false, features = [] }
 
 libc = "0.2.153" # TODO remove
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,8 +34,6 @@ libz-sys = { version = "1.1.12", default-features = false, features = ["zlib-ng"
 arbitrary = { version = "1.0" }
 quickcheck = { version = "1.0.3", default-features = false, features = [] }
 
-libc = "0.2.153" # TODO remove
-
 zlib-rs = { version = "0.1.1", path = "./zlib-rs" }
 load-dynamic-libz-ng = { path = "./load-dynamic-libz-ng" }
 

--- a/libz-rs-sys/Cargo.toml
+++ b/libz-rs-sys/Cargo.toml
@@ -15,9 +15,9 @@ crate-type=["rlib", "cdylib"]
 
 [features]
 default = ["std", "rust-allocator"] # when used as a rust crate, use the rust allocator
-c-allocator = [] # by default, use malloc/free for memory allocation
-rust-allocator = [] # by default, use the rust global alloctor for memory allocation
-std = [] # assume `::std` is available
+c-allocator = ["zlib-rs/c-allocator"] # by default, use malloc/free for memory allocation
+rust-allocator = ["zlib-rs/rust-allocator"] # by default, use the rust global alloctor for memory allocation
+std = ["zlib-rs/std"] # assume `::std` is available
 
 [dependencies]
 zlib-rs = { workspace = true }

--- a/libz-rs-sys/Cargo.toml
+++ b/libz-rs-sys/Cargo.toml
@@ -21,7 +21,6 @@ std = [] # assume `::std` is available
 
 [dependencies]
 zlib-rs = { workspace = true }
-libc.workspace = true
 
 [dev-dependencies]
 zlib-rs = { workspace = true, features = [ "__internal-test" ] }

--- a/libz-rs-sys/Cargo.toml
+++ b/libz-rs-sys/Cargo.toml
@@ -20,10 +20,10 @@ rust-allocator = ["zlib-rs/rust-allocator"] # by default, use the rust global al
 std = ["zlib-rs/std"] # assume `::std` is available
 
 [dependencies]
-zlib-rs = { workspace = true }
+zlib-rs = { workspace = true, default-features = false }
 
 [dev-dependencies]
-zlib-rs = { workspace = true, features = [ "__internal-test" ] }
+zlib-rs = { workspace = true, default-features = false, features = ["std", "__internal-test"] }
 libz-sys.workspace = true
 libloading.workspace = true
 load-dynamic-libz-ng.workspace = true

--- a/libz-rs-sys/Cargo.toml
+++ b/libz-rs-sys/Cargo.toml
@@ -28,5 +28,5 @@ zlib-rs = { workspace = true, features = [ "__internal-test" ] }
 libz-sys.workspace = true
 libloading.workspace = true
 load-dynamic-libz-ng.workspace = true
+quickcheck.workspace = true
 crc32fast = "1.3.2"
-quickcheck = "1.0.3"

--- a/libz-rs-sys/src/lib.rs
+++ b/libz-rs-sys/src/lib.rs
@@ -61,10 +61,9 @@ const DEFAULT_ZFREE: Option<free_func> = '_blk: {
     None
 };
 
-#[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
-pub type z_off_t = libc::off_t;
-
-#[cfg(all(target_family = "wasm", target_os = "unknown"))]
+// In spirit this type is `libc::off_t`, but it would be our only libc dependency, and so we
+// hardcode the type here. This should be correct on most operating systems. If we ever run into
+// issues with it, we can either special-case or add a feature flag to force a particular width
 pub type z_off_t = c_long;
 
 pub unsafe extern "C" fn crc32(crc: c_ulong, buf: *const Bytef, len: uInt) -> c_ulong {

--- a/libz-rs-sys/src/lib.rs
+++ b/libz-rs-sys/src/lib.rs
@@ -20,9 +20,9 @@
 #[cfg(test)]
 mod tests;
 
-use std::mem::MaybeUninit;
+use core::mem::MaybeUninit;
 
-use std::ffi::{c_char, c_int, c_long, c_uchar, c_uint, c_ulong, c_void};
+use core::ffi::{c_char, c_int, c_long, c_uchar, c_uint, c_ulong, c_void};
 
 use zlib_rs::{
     deflate::{DeflateConfig, DeflateStream, Method, Strategy},
@@ -68,7 +68,7 @@ pub type z_off_t = libc::off_t;
 pub type z_off_t = c_long;
 
 pub unsafe extern "C" fn crc32(crc: c_ulong, buf: *const Bytef, len: uInt) -> c_ulong {
-    let buf = unsafe { std::slice::from_raw_parts(buf, len as usize) };
+    let buf = unsafe { core::slice::from_raw_parts(buf, len as usize) };
     zlib_rs::crc32(crc as u32, buf) as c_ulong
 }
 
@@ -77,7 +77,7 @@ pub unsafe extern "C" fn crc32_combine(crc1: c_ulong, crc2: c_ulong, len2: z_off
 }
 
 pub unsafe extern "C" fn adler32(adler: c_ulong, buf: *const Bytef, len: uInt) -> c_ulong {
-    let buf = unsafe { std::slice::from_raw_parts(buf, len as usize) };
+    let buf = unsafe { core::slice::from_raw_parts(buf, len as usize) };
     zlib_rs::adler32(adler as u32, buf) as c_ulong
 }
 
@@ -115,16 +115,16 @@ pub unsafe extern "C" fn uncompress(
     sourceLen: c_ulong,
 ) -> c_int {
     let data = dest;
-    let len = std::ptr::read(destLen) as usize;
-    let output = std::slice::from_raw_parts_mut(data as *mut MaybeUninit<u8>, len);
+    let len = core::ptr::read(destLen) as usize;
+    let output = core::slice::from_raw_parts_mut(data as *mut MaybeUninit<u8>, len);
 
     let data = source;
     let len = sourceLen as usize;
-    let input = std::slice::from_raw_parts(data, len);
+    let input = core::slice::from_raw_parts(data, len);
 
     let (output, err) = zlib_rs::inflate::uncompress(output, input, InflateConfig::default());
 
-    std::ptr::write(destLen, output.len() as _);
+    core::ptr::write(destLen, output.len() as _);
 
     err as c_int
 }
@@ -248,7 +248,7 @@ pub unsafe extern "C" fn inflateInit2(strm: z_streamp, windowBits: c_int) -> c_i
 
         if stream.zalloc.is_none() {
             stream.zalloc = DEFAULT_ZALLOC;
-            stream.opaque = std::ptr::null_mut();
+            stream.opaque = core::ptr::null_mut();
         }
 
         if stream.zfree.is_none() {
@@ -298,7 +298,7 @@ pub unsafe extern "C" fn inflateSetDictionary(
     let dict = if dictLength == 0 || dictionary.is_null() {
         &[]
     } else {
-        unsafe { std::slice::from_raw_parts(dictionary, dictLength as usize) }
+        unsafe { core::slice::from_raw_parts(dictionary, dictLength as usize) }
     };
 
     zlib_rs::inflate::set_dictionary(stream, dict) as _
@@ -395,17 +395,17 @@ pub unsafe extern "C" fn compress2(
     level: c_int,
 ) -> c_int {
     let data = dest;
-    let len = std::ptr::read(destLen) as usize;
-    let output = std::slice::from_raw_parts_mut(data as *mut MaybeUninit<u8>, len);
+    let len = core::ptr::read(destLen) as usize;
+    let output = core::slice::from_raw_parts_mut(data as *mut MaybeUninit<u8>, len);
 
     let data = source;
     let len = sourceLen as usize;
-    let input = std::slice::from_raw_parts(data, len);
+    let input = core::slice::from_raw_parts(data, len);
 
     let config = DeflateConfig::new(level);
     let (output, err) = zlib_rs::deflate::compress(output, input, config);
 
-    std::ptr::write(destLen, output.len() as _);
+    core::ptr::write(destLen, output.len() as _);
 
     err as c_int
 }
@@ -513,7 +513,7 @@ pub unsafe extern "C" fn deflateInit_(
 
         if stream.zalloc.is_none() {
             stream.zalloc = DEFAULT_ZALLOC;
-            stream.opaque = std::ptr::null_mut();
+            stream.opaque = core::ptr::null_mut();
         }
 
         if stream.zfree.is_none() {
@@ -559,7 +559,7 @@ pub unsafe extern "C" fn deflateInit2_(
 
         if stream.zalloc.is_none() {
             stream.zalloc = DEFAULT_ZALLOC;
-            stream.opaque = std::ptr::null_mut();
+            stream.opaque = core::ptr::null_mut();
         }
 
         if stream.zfree.is_none() {

--- a/libz-rs-sys/src/lib.rs
+++ b/libz-rs-sys/src/lib.rs
@@ -37,26 +37,26 @@ const _: () =
     compile_error!("Only one of `rust-allocator` and `c-allocator` can be enabled at a time");
 
 #[allow(unreachable_code)]
-const DEFAULT_ZALLOC: Option<alloc_func> = 'blk: {
+const DEFAULT_ZALLOC: Option<alloc_func> = '_blk: {
     // this `break 'blk'` construction exists to generate just one compile error and not other
     // warnings when multiple allocators are configured.
 
     #[cfg(feature = "c-allocator")]
-    break 'blk Some(zlib_rs::allocate::zalloc_c);
+    break '_blk Some(zlib_rs::allocate::zalloc_c);
 
     #[cfg(feature = "rust-allocator")]
-    break 'blk Some(zlib_rs::allocate::zalloc_rust);
+    break '_blk Some(zlib_rs::allocate::zalloc_rust);
 
     None
 };
 
 #[allow(unreachable_code)]
-const DEFAULT_ZFREE: Option<free_func> = 'blk: {
+const DEFAULT_ZFREE: Option<free_func> = '_blk: {
     #[cfg(feature = "c-allocator")]
-    break 'blk Some(zlib_rs::allocate::zfree_c);
+    break '_blk Some(zlib_rs::allocate::zfree_c);
 
     #[cfg(feature = "rust-allocator")]
-    break 'blk Some(zlib_rs::allocate::zfree_rust);
+    break '_blk Some(zlib_rs::allocate::zfree_rust);
 
     None
 };

--- a/libz-rs-sys/src/tests/deflate.rs
+++ b/libz-rs-sys/src/tests/deflate.rs
@@ -19,7 +19,7 @@ use zlib_rs::{
 };
 
 const VERSION: *const c_char = libz_rs_sys::zlibVersion();
-const STREAM_SIZE: c_int = std::mem::size_of::<libz_rs_sys::z_stream>() as c_int;
+const STREAM_SIZE: c_int = core::mem::size_of::<libz_rs_sys::z_stream>() as c_int;
 
 pub mod quick {
     use super::*;

--- a/libz-rs-sys/src/tests/inflate.rs
+++ b/libz-rs-sys/src/tests/inflate.rs
@@ -1,4 +1,4 @@
-use std::mem::ManuallyDrop;
+use core::mem::ManuallyDrop;
 
 use crate as libz_rs_sys;
 
@@ -9,7 +9,7 @@ use zlib_rs::inflate::{set_mode_dict, uncompress_slice, INFLATE_STATE_SIZE};
 use zlib_rs::MAX_WBITS;
 
 const VERSION: *const c_char = libz_rs_sys::zlibVersion();
-const STREAM_SIZE: c_int = std::mem::size_of::<libz_rs_sys::z_stream>() as c_int;
+const STREAM_SIZE: c_int = core::mem::size_of::<libz_rs_sys::z_stream>() as c_int;
 
 #[derive(Clone, Copy)]
 struct MemItem {
@@ -1207,7 +1207,7 @@ fn gzip_chunked(chunk_size: usize) {
     let mut stream = MaybeUninit::<libz_rs_sys::z_stream>::zeroed();
 
     const VERSION: *const c_char = libz_rs_sys::zlibVersion();
-    const STREAM_SIZE: c_int = std::mem::size_of::<libz_rs_sys::z_stream>() as c_int;
+    const STREAM_SIZE: c_int = core::mem::size_of::<libz_rs_sys::z_stream>() as c_int;
 
     let err = unsafe {
         libz_rs_sys::deflateInit2_(
@@ -1274,7 +1274,7 @@ fn gzip_chunked(chunk_size: usize) {
         let mut stream = MaybeUninit::<z_stream>::zeroed();
 
         const VERSION: *const c_char = libz_rs_sys::zlibVersion();
-        const STREAM_SIZE: c_int = std::mem::size_of::<z_stream>() as c_int;
+        const STREAM_SIZE: c_int = core::mem::size_of::<z_stream>() as c_int;
 
         let err = unsafe {
             inflateInit2_(

--- a/zlib-rs/Cargo.toml
+++ b/zlib-rs/Cargo.toml
@@ -13,8 +13,8 @@ rust-version.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-default = ["std", "alloc"]
-std = []
+default = ["std"]
+std = ["alloc"]
 alloc = []
 __internal-fuzz = ["arbitrary"]
 __internal-test = ["quickcheck"]

--- a/zlib-rs/Cargo.toml
+++ b/zlib-rs/Cargo.toml
@@ -23,10 +23,11 @@ __internal-test = ["quickcheck"]
 [dependencies]
 arbitrary = { workspace = true, optional = true, features = ["derive"] }
 libz-sys = { workspace = true, optional = true }
-quickcheck = { version = "1.0.3", optional = true, default-features = false, features = [] }
+quickcheck = { workspace = true, optional = true }
 
 [dev-dependencies]
 libloading = "0.8.1"
 libz-ng-sys = "1.1.12"
 crc32fast = "1.3.2"
+quickcheck.workspace = true
 load-dynamic-libz-ng.workspace = true

--- a/zlib-rs/Cargo.toml
+++ b/zlib-rs/Cargo.toml
@@ -13,9 +13,10 @@ rust-version.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-default = ["std"]
-std = ["alloc"]
-alloc = []
+default = ["std", "c-allocator"]
+std = ["rust-allocator"]
+c-allocator = [] # expose a malloc-based C allocator
+rust-allocator = [] # expose a rust global alloctor
 __internal-fuzz = ["arbitrary"]
 __internal-test = ["quickcheck"]
 

--- a/zlib-rs/Cargo.toml
+++ b/zlib-rs/Cargo.toml
@@ -13,7 +13,9 @@ rust-version.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-default = []
+default = ["std", "alloc"]
+std = []
+alloc = []
 __internal-fuzz = ["arbitrary"]
 __internal-test = ["quickcheck"]
 

--- a/zlib-rs/src/adler32.rs
+++ b/zlib-rs/src/adler32.rs
@@ -8,7 +8,7 @@ mod neon;
 
 pub fn adler32(start_checksum: u32, data: &[u8]) -> u32 {
     #[cfg(all(target_arch = "x86_64", feature = "std"))]
-    if core::is_x86_feature_detected!("avx2") {
+    if std::is_x86_feature_detected!("avx2") {
         return avx2::adler32_avx2(start_checksum, data);
     }
 

--- a/zlib-rs/src/adler32.rs
+++ b/zlib-rs/src/adler32.rs
@@ -1,4 +1,4 @@
-use std::mem::MaybeUninit;
+use core::mem::MaybeUninit;
 
 #[cfg(target_arch = "x86_64")]
 mod avx2;
@@ -7,12 +7,12 @@ mod generic;
 mod neon;
 
 pub fn adler32(start_checksum: u32, data: &[u8]) -> u32 {
-    #[cfg(target_arch = "x86_64")]
-    if std::is_x86_feature_detected!("avx2") {
+    #[cfg(all(target_arch = "x86_64", feature = "std"))]
+    if core::is_x86_feature_detected!("avx2") {
         return avx2::adler32_avx2(start_checksum, data);
     }
 
-    #[cfg(target_arch = "aarch64")]
+    #[cfg(all(target_arch = "aarch64", feature = "std"))]
     if std::arch::is_aarch64_feature_detected!("neon") {
         return self::neon::adler32_neon(start_checksum, data);
     }
@@ -23,7 +23,7 @@ pub fn adler32(start_checksum: u32, data: &[u8]) -> u32 {
 pub fn adler32_fold_copy(start_checksum: u32, dst: &mut [MaybeUninit<u8>], src: &[u8]) -> u32 {
     debug_assert!(dst.len() >= src.len(), "{} < {}", dst.len(), src.len());
 
-    #[cfg(target_arch = "x86_64")]
+    #[cfg(all(target_arch = "x86_64", feature = "std"))]
     if std::is_x86_feature_detected!("avx2") {
         return avx2::adler32_fold_copy_avx2(start_checksum, dst, src);
     }

--- a/zlib-rs/src/adler32/avx2.rs
+++ b/zlib-rs/src/adler32/avx2.rs
@@ -14,7 +14,7 @@ use crate::adler32::{
 };
 
 const fn __m256i_literal(bytes: [u8; 32]) -> __m256i {
-    unsafe { std::mem::transmute(bytes) }
+    unsafe { core::mem::transmute(bytes) }
 }
 
 const DOT2V: __m256i = __m256i_literal([

--- a/zlib-rs/src/adler32/generic.rs
+++ b/zlib-rs/src/adler32/generic.rs
@@ -1,4 +1,4 @@
-use std::mem::MaybeUninit;
+use core::mem::MaybeUninit;
 
 use super::{BASE, NMAX};
 

--- a/zlib-rs/src/allocate.rs
+++ b/zlib-rs/src/allocate.rs
@@ -1,11 +1,13 @@
-use std::{
-    alloc::{GlobalAlloc, Layout},
+use core::ffi::c_int;
+use core::{
+    alloc::Layout,
     ffi::{c_uint, c_void},
     marker::PhantomData,
     mem::MaybeUninit,
 };
 
-use std::ffi::c_int;
+#[cfg(feature = "alloc")]
+use alloc::alloc::GlobalAlloc;
 
 #[allow(non_camel_case_types)]
 type size_t = usize;
@@ -21,10 +23,10 @@ pub unsafe extern "C" fn zalloc_c(opaque: *mut c_void, items: c_uint, size: c_ui
         fn posix_memalign(memptr: *mut *mut c_void, align: size_t, size: size_t) -> c_int;
     }
 
-    let mut ptr = std::ptr::null_mut();
+    let mut ptr = core::ptr::null_mut();
     match posix_memalign(&mut ptr, 64, items as size_t * size as size_t) {
         0 => ptr,
-        _ => std::ptr::null_mut(),
+        _ => core::ptr::null_mut(),
     }
 }
 
@@ -58,6 +60,7 @@ pub unsafe extern "C" fn zfree_c(opaque: *mut c_void, ptr: *mut c_void) {
 /// # Safety
 ///
 /// This function is safe to call.
+#[cfg(feature = "alloc")]
 pub unsafe extern "C" fn zalloc_rust(
     _opaque: *mut c_void,
     count: c_uint,
@@ -78,6 +81,7 @@ pub unsafe extern "C" fn zalloc_rust(
 ///
 /// - `ptr` must be allocated with the rust `alloc::System` allocator
 /// - `opaque` is a `&usize` that represents the size of the allocation
+#[cfg(feature = "alloc")]
 pub unsafe extern "C" fn zfree_rust(opaque: *mut c_void, ptr: *mut c_void) {
     if ptr.is_null() {
         return;
@@ -108,6 +112,7 @@ pub(crate) struct Allocator<'a> {
 }
 
 impl Allocator<'static> {
+    #[cfg(feature = "alloc")]
     pub const RUST: Self = Self {
         zalloc: zalloc_rust,
         zfree: zfree_rust,
@@ -125,75 +130,83 @@ impl Allocator<'static> {
 
 impl<'a> Allocator<'a> {
     fn allocate_layout(&self, layout: Layout) -> *mut c_void {
-        let ptr = if self.zalloc == Allocator::RUST.zalloc {
-            unsafe { (Allocator::RUST.zalloc)(self.opaque, layout.size() as _, 1) }
-        } else {
-            // We cannot rely on the allocator giving properly aligned allocations and have to fix that ourselves.
+        // Special case for the Rust `alloc` backed allocator
+        #[cfg(feature = "alloc")]
+        if self.zalloc == Allocator::RUST.zalloc {
+            let ptr = unsafe { (Allocator::RUST.zalloc)(self.opaque, layout.size() as _, 1) };
+
+            debug_assert_eq!(ptr as usize % layout.align(), 0);
+
+            return ptr;
+        }
+
+        // General case for c-style allocation
+
+        // We cannot rely on the allocator giving properly aligned allocations and have to fix that ourselves.
+        //
+        // The general approach is to allocate a bit more than the layout needs, so that we can
+        // give the application a properly aligned address and also store the real allocation
+        // pointer in the allocation so that `free` can free the real allocation pointer.
+        //
+        //
+        // Example: The layout represents `(u32, u32)`, with an alignment of 4 bytes and a
+        // total size of 8 bytes.
+        //
+        // Assume that the allocator will give us address `0x07`. We need that to be a multiple
+        // of the alignment, so that shifts the starting position to `0x08`. Then we also need
+        // to store the pointer to the start of the allocation so that `free` can free that
+        // pointer, bumping to `0x10`. The `0x10` pointer is then the pointer that the application
+        // deals with. When free'ing, the original allocation pointer can be read from `0x10 - size_of::<*const c_void>()`.
+        //
+        // Of course there does need to be enough space in the allocation such that when we
+        // shift the start forwards, the end is still within the allocation. Hence we allocate
+        // `extra_space` bytes: enough for a full alignment plus a pointer.
+
+        // we need at least
+        //
+        // - `align` extra space so that no matter what pointer we get from zalloc, we can shift the start of the
+        //      allocation by at most `align - 1` so that `ptr as usize % align == 0
+        // - `size_of::<*mut _>` extra space so that after aligning to `align`,
+        //      there is `size_of::<*mut _>` space to store the pointer to the allocation.
+        //      This pointer is then retrieved in `free`
+        let extra_space = core::mem::size_of::<*mut c_void>() + layout.align();
+
+        // Safety: we assume allocating works correctly in the safety assumptions on
+        // `DeflateStream` and `InflateStream`.
+        let ptr = unsafe { (self.zalloc)(self.opaque, (layout.size() + extra_space) as _, 1) };
+
+        if ptr.is_null() {
+            return ptr;
+        }
+
+        // Calculate return pointer address with space enough to store original pointer
+        let align_diff = (ptr as usize).next_multiple_of(layout.align()) - (ptr as usize);
+
+        // Safety: offset is smaller than 64, and we allocated 64 extra bytes in the allocation
+        let mut return_ptr = unsafe { ptr.cast::<u8>().add(align_diff) };
+
+        // if there is not enough space to store a pointer we need to make more
+        if align_diff < core::mem::size_of::<*mut c_void>() {
+            // # Safety
             //
-            // The general approach is to allocate a bit more than the layout needs, so that we can
-            // give the application a properly aligned address and also store the real allocation
-            // pointer in the allocation so that `free` can free the real allocation pointer.
-            //
-            //
-            // Example: The layout represents `(u32, u32)`, with an alignment of 4 bytes and a
-            // total size of 8 bytes.
-            //
-            // Assume that the allocator will give us address `0x07`. We need that to be a multiple
-            // of the alignment, so that shifts the starting position to `0x08`. Then we also need
-            // to store the pointer to the start of the allocation so that `free` can free that
-            // pointer, bumping to `0x10`. The `0x10` pointer is then the pointer that the application
-            // deals with. When free'ing, the original allocation pointer can be read from `0x10 - size_of::<*const c_void>()`.
-            //
-            // Of course there does need to be enough space in the allocation such that when we
-            // shift the start forwards, the end is still within the allocation. Hence we allocate
-            // `extra_space` bytes: enough for a full alignment plus a pointer.
+            // - `return_ptr` is well-aligned, therefore `return_ptr + align` is also well-aligned
+            // - we reserve `size_of::<*mut _> + align` extra space in the allocation, so
+            //      `ptr + align_diff + align` is still valid for (at least) `layout.size` bytes
+            let offset = Ord::max(core::mem::size_of::<*mut c_void>(), layout.align());
+            return_ptr = unsafe { return_ptr.add(offset) };
+        }
 
-            // we need at least
-            //
-            // - `align` extra space so that no matter what pointer we get from zalloc, we can shift the start of the
-            //      allocation by at most `align - 1` so that `ptr as usize % align == 0
-            // - `size_of::<*mut _>` extra space so that after aligning to `align`,
-            //      there is `size_of::<*mut _>` space to store the pointer to the allocation.
-            //      This pointer is then retrieved in `free`
-            let extra_space = core::mem::size_of::<*mut c_void>() + layout.align();
-
-            // Safety: we assume allocating works correctly in the safety assumptions on
-            // `DeflateStream` and `InflateStream`.
-            let ptr = unsafe { (self.zalloc)(self.opaque, (layout.size() + extra_space) as _, 1) };
-
-            if ptr.is_null() {
-                return ptr;
-            }
-
-            // Calculate return pointer address with space enough to store original pointer
-            let align_diff = (ptr as usize).next_multiple_of(layout.align()) - (ptr as usize);
-
-            // Safety: offset is smaller than 64, and we allocated 64 extra bytes in the allocation
-            let mut return_ptr = unsafe { ptr.cast::<u8>().add(align_diff) };
-
-            // if there is not enough space to store a pointer we need to make more
-            if align_diff < core::mem::size_of::<*mut c_void>() {
-                // # Safety
-                //
-                // - `return_ptr` is well-aligned, therefore `return_ptr + align` is also well-aligned
-                // - we reserve `size_of::<*mut _> + align` extra space in the allocation, so
-                //      `ptr + align_diff + align` is still valid for (at least) `layout.size` bytes
-                let offset = Ord::max(core::mem::size_of::<*mut c_void>(), layout.align());
-                return_ptr = unsafe { return_ptr.add(offset) };
-            }
-
-            // Store the original pointer for free()
-            //
-            // Safety: `align >= size_of::<*mut _>`, so there is now space for a pointer before `return_ptr`
-            // in the allocation
-            unsafe {
-                let original_ptr = return_ptr.sub(core::mem::size_of::<*mut c_void>());
-                std::ptr::write_unaligned(original_ptr.cast::<*mut c_void>(), ptr);
-            };
-
-            // Return properly aligned pointer in allocation
-            return_ptr.cast::<c_void>()
+        // Store the original pointer for free()
+        //
+        // Safety: `align >= size_of::<*mut _>`, so there is now space for a pointer before `return_ptr`
+        // in the allocation
+        unsafe {
+            let original_ptr = return_ptr.sub(core::mem::size_of::<*mut c_void>());
+            core::ptr::write_unaligned(original_ptr.cast::<*mut c_void>(), ptr);
         };
+
+        // Return properly aligned pointer in allocation
+        let ptr = return_ptr.cast::<c_void>();
 
         debug_assert_eq!(ptr as usize % layout.align(), 0);
 
@@ -228,25 +241,29 @@ impl<'a> Allocator<'a> {
     ///
     /// - `ptr` must be allocated with this allocator
     /// - `len` must be the number of `T`s that are in this allocation
+    #[allow(unused)] // Rust needs `len` for deallocation
     pub unsafe fn deallocate<T>(&self, ptr: *mut T, len: usize) {
         if !ptr.is_null() {
+            // Special case for the Rust `alloc` backed allocator
+            #[cfg(feature = "alloc")]
             if self.zfree == Allocator::RUST.zfree {
                 assert_ne!(len, 0, "invalid size for {:?}", ptr);
                 let mut size = core::mem::size_of::<T>() * len;
-                (Allocator::RUST.zfree)(&mut size as *mut usize as *mut c_void, ptr.cast())
-            } else {
-                let original_ptr = (ptr as *mut u8).sub(core::mem::size_of::<*const c_void>());
-                let free_ptr = core::ptr::read_unaligned(original_ptr as *mut *mut c_void);
-
-                (self.zfree)(self.opaque, free_ptr)
+                return (Allocator::RUST.zfree)(&mut size as *mut usize as *mut c_void, ptr.cast());
             }
+
+            // General case for c-style allocation
+            let original_ptr = (ptr as *mut u8).sub(core::mem::size_of::<*const c_void>());
+            let free_ptr = core::ptr::read_unaligned(original_ptr as *mut *mut c_void);
+
+            (self.zfree)(self.opaque, free_ptr)
         }
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use std::sync::atomic::{AtomicPtr, Ordering};
+    use core::sync::atomic::{AtomicPtr, Ordering};
 
     use super::*;
 

--- a/zlib-rs/src/c_api.rs
+++ b/zlib-rs/src/c_api.rs
@@ -66,11 +66,12 @@ impl z_stream {
         self.opaque = alloc.opaque;
     }
 
-    #[cfg(feature = "alloc")]
+    #[cfg(feature = "rust-allocator")]
     pub fn configure_default_rust_allocator(&mut self) {
         self.configure_allocator(Allocator::RUST)
     }
 
+    #[cfg(feature = "c-allocator")]
     pub fn configure_default_c_allocator(&mut self) {
         self.configure_allocator(Allocator::C)
     }

--- a/zlib-rs/src/c_api.rs
+++ b/zlib-rs/src/c_api.rs
@@ -1,7 +1,7 @@
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]
 
-use std::ffi::{c_char, c_int, c_uchar, c_uint, c_ulong, c_void};
+use core::ffi::{c_char, c_int, c_uchar, c_uint, c_ulong, c_void};
 
 use crate::allocate::Allocator;
 
@@ -41,17 +41,17 @@ pub type z_streamp = *mut z_stream;
 impl Default for z_stream {
     fn default() -> Self {
         Self {
-            next_in: std::ptr::null_mut(),
+            next_in: core::ptr::null_mut(),
             avail_in: 0,
             total_in: 0,
-            next_out: std::ptr::null_mut(),
+            next_out: core::ptr::null_mut(),
             avail_out: 0,
             total_out: 0,
-            msg: std::ptr::null_mut(),
-            state: std::ptr::null_mut(),
+            msg: core::ptr::null_mut(),
+            state: core::ptr::null_mut(),
             zalloc: Some(crate::allocate::zalloc_c),
             zfree: Some(crate::allocate::zfree_c),
-            opaque: std::ptr::null_mut(),
+            opaque: core::ptr::null_mut(),
             data_type: 0,
             adler: 0,
             reserved: 0,
@@ -66,6 +66,7 @@ impl z_stream {
         self.opaque = alloc.opaque;
     }
 
+    #[cfg(feature = "alloc")]
     pub fn configure_default_rust_allocator(&mut self) {
         self.configure_allocator(Allocator::RUST)
     }
@@ -160,12 +161,12 @@ impl Default for gz_header {
             time: 0,
             xflags: 0,
             os: 0,
-            extra: std::ptr::null_mut(),
+            extra: core::ptr::null_mut(),
             extra_len: 0,
             extra_max: 0,
-            name: std::ptr::null_mut(),
+            name: core::ptr::null_mut(),
             name_max: 0,
-            comment: std::ptr::null_mut(),
+            comment: core::ptr::null_mut(),
             comm_max: 0,
             hcrc: 0,
             done: 0,

--- a/zlib-rs/src/crc32.rs
+++ b/zlib-rs/src/crc32.rs
@@ -2,7 +2,7 @@ use core::mem::MaybeUninit;
 
 use crate::{read_buf::ReadBuf, CRC32_INITIAL_VALUE};
 
-#[cfg(any(target_arch = "aarch64", target_arch = "arm"))]
+#[cfg(target_arch = "aarch64")]
 pub(crate) mod acle;
 mod braid;
 mod combine;
@@ -87,12 +87,6 @@ impl Crc32Fold {
         #[cfg(all(target_arch = "aarch64", feature = "std"))]
         if std::arch::is_aarch64_feature_detected!("crc") {
             self.value = self::acle::crc32_acle_aarch64(self.value, src);
-            return;
-        }
-
-        #[cfg(target_arch = "arm")]
-        if is_arm_feature_detected("crc") {
-            self.value = self::acle::crc32_acle_arm(self.value, src);
             return;
         }
 

--- a/zlib-rs/src/crc32.rs
+++ b/zlib-rs/src/crc32.rs
@@ -1,4 +1,4 @@
-use std::mem::MaybeUninit;
+use core::mem::MaybeUninit;
 
 use crate::{read_buf::ReadBuf, CRC32_INITIAL_VALUE};
 
@@ -71,20 +71,20 @@ impl Crc32Fold {
         }
     }
 
-    #[cfg(target_arch = "x86_64")]
+    #[cfg(all(target_arch = "x86_64", feature = "std"))]
     fn is_pclmulqdq() -> bool {
-        is_x86_feature_detected!("pclmulqdq")
-            && is_x86_feature_detected!("sse2")
-            && is_x86_feature_detected!("sse4.1")
+        std::is_x86_feature_detected!("pclmulqdq")
+            && std::is_x86_feature_detected!("sse2")
+            && std::is_x86_feature_detected!("sse4.1")
     }
 
     pub fn fold(&mut self, src: &[u8], _start: u32) {
-        #[cfg(target_arch = "x86_64")]
+        #[cfg(all(target_arch = "x86_64", feature = "std"))]
         if Self::is_pclmulqdq() {
             return self.fold.fold(src, _start);
         }
 
-        #[cfg(target_arch = "aarch64")]
+        #[cfg(all(target_arch = "aarch64", feature = "std"))]
         if std::arch::is_aarch64_feature_detected!("crc") {
             self.value = self::acle::crc32_acle_aarch64(self.value, src);
             return;
@@ -101,7 +101,7 @@ impl Crc32Fold {
     }
 
     pub fn fold_copy(&mut self, dst: &mut [MaybeUninit<u8>], src: &[u8]) {
-        #[cfg(target_arch = "x86_64")]
+        #[cfg(all(target_arch = "x86_64", feature = "std"))]
         if Self::is_pclmulqdq() {
             return self.fold.fold_copy(dst, src);
         }
@@ -111,7 +111,7 @@ impl Crc32Fold {
     }
 
     pub fn finish(self) -> u32 {
-        #[cfg(target_arch = "x86_64")]
+        #[cfg(all(target_arch = "x86_64", feature = "std"))]
         if Self::is_pclmulqdq() {
             return unsafe { self.fold.finish() };
         }

--- a/zlib-rs/src/crc32/acle.rs
+++ b/zlib-rs/src/crc32/acle.rs
@@ -67,7 +67,7 @@ fn remainder(mut c: u32, mut buf: &[u8]) -> u32 {
 #[target_feature(enable = "crc")]
 #[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
 unsafe fn __crc32b(mut crc: u32, data: u8) -> u32 {
-    std::arch::asm!("crc32b {crc:w}, {crc:w}, {data:w}", crc = inout(reg) crc, data = in(reg) data);
+    core::arch::asm!("crc32b {crc:w}, {crc:w}, {data:w}", crc = inout(reg) crc, data = in(reg) data);
     crc
 }
 
@@ -77,7 +77,7 @@ unsafe fn __crc32b(mut crc: u32, data: u8) -> u32 {
 #[target_feature(enable = "crc")]
 #[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
 unsafe fn __crc32h(mut crc: u32, data: u16) -> u32 {
-    std::arch::asm!("crc32h {crc:w}, {crc:w}, {data:w}", crc = inout(reg) crc, data = in(reg) data);
+    core::arch::asm!("crc32h {crc:w}, {crc:w}, {data:w}", crc = inout(reg) crc, data = in(reg) data);
     crc
 }
 
@@ -87,7 +87,7 @@ unsafe fn __crc32h(mut crc: u32, data: u16) -> u32 {
 #[target_feature(enable = "crc")]
 #[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
 unsafe fn __crc32w(mut crc: u32, data: u32) -> u32 {
-    std::arch::asm!("crc32w {crc:w}, {crc:w}, {data:w}", crc = inout(reg) crc, data = in(reg) data);
+    core::arch::asm!("crc32w {crc:w}, {crc:w}, {data:w}", crc = inout(reg) crc, data = in(reg) data);
     crc
 }
 
@@ -97,7 +97,7 @@ unsafe fn __crc32w(mut crc: u32, data: u32) -> u32 {
 #[cfg(target_arch = "aarch64")]
 #[target_feature(enable = "crc")]
 unsafe fn __crc32d(mut crc: u32, data: u64) -> u32 {
-    std::arch::asm!("crc32x {crc:w}, {crc:w}, {data:x}", crc = inout(reg) crc, data = in(reg) data);
+    core::arch::asm!("crc32x {crc:w}, {crc:w}, {data:x}", crc = inout(reg) crc, data = in(reg) data);
     crc
 }
 
@@ -107,7 +107,7 @@ unsafe fn __crc32d(mut crc: u32, data: u64) -> u32 {
 #[target_feature(enable = "crc")]
 #[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
 pub unsafe fn __crc32cw(mut crc: u32, data: u32) -> u32 {
-    std::arch::asm!("crc32cw {crc:w}, {crc:w}, {data:w}", crc = inout(reg) crc, data = in(reg) data);
+    core::arch::asm!("crc32cw {crc:w}, {crc:w}, {data:w}", crc = inout(reg) crc, data = in(reg) data);
     crc
 }
 

--- a/zlib-rs/src/crc32/pclmulqdq.rs
+++ b/zlib-rs/src/crc32/pclmulqdq.rs
@@ -1,5 +1,5 @@
 use core::arch::x86_64::__m128i;
-use std::{
+use core::{
     arch::x86_64::{
         _mm_and_si128, _mm_clmulepi64_si128, _mm_extract_epi32, _mm_load_si128, _mm_loadu_si128,
         _mm_or_si128, _mm_shuffle_epi8, _mm_slli_si128, _mm_srli_si128, _mm_storeu_si128,
@@ -128,7 +128,7 @@ impl Accumulator {
     }
 
     fn fold_step<const N: usize>(&mut self) {
-        self.fold = std::array::from_fn(|i| match self.fold.get(i + N) {
+        self.fold = core::array::from_fn(|i| match self.fold.get(i + N) {
             Some(v) => *v,
             None => unsafe { Self::step(self.fold[(i + N) - 4]) },
         });
@@ -197,7 +197,7 @@ impl Accumulator {
         init_crc: &mut u32,
     ) -> usize {
         let mut it = src.chunks_exact(16);
-        let mut input: [_; N] = std::array::from_fn(|_| unsafe {
+        let mut input: [_; N] = core::array::from_fn(|_| unsafe {
             _mm_load_si128(it.next().unwrap().as_ptr() as *const __m128i)
         });
 
@@ -322,14 +322,14 @@ impl Accumulator {
         }
 
         if !src.is_empty() {
-            std::ptr::copy_nonoverlapping(
+            core::ptr::copy_nonoverlapping(
                 src.as_ptr(),
                 &mut xmm_crc_part as *mut _ as *mut u8,
                 src.len(),
             );
             if COPY {
                 _mm_storeu_si128(partial_buf.0.as_mut_ptr() as *mut __m128i, xmm_crc_part);
-                std::ptr::copy_nonoverlapping(
+                core::ptr::copy_nonoverlapping(
                     partial_buf.0.as_ptr() as *const MaybeUninit<u8>,
                     dst.as_mut_ptr(),
                     src.len(),

--- a/zlib-rs/src/deflate.rs
+++ b/zlib-rs/src/deflate.rs
@@ -198,13 +198,13 @@ pub fn init(stream: &mut z_stream, config: DeflateConfig) -> ReturnCode {
     // this is a (slight) deviation from stock zlib. In this crate we pick the rust
     // allocator as the default, but `libz-rs-sys` always explicitly sets an allocator,
     // and can configure the C allocator
-    #[cfg(feature = "alloc")]
+    #[cfg(feature = "rust-allocator")]
     if stream.zalloc.is_none() || stream.zfree.is_none() {
         stream.configure_default_rust_allocator()
     }
 
-    #[cfg(not(feature = "alloc"))]
-    if cfg!(test) && stream.zalloc.is_none() || stream.zfree.is_none() {
+    #[cfg(feature = "c-allocator")]
+    if stream.zalloc.is_none() || stream.zfree.is_none() {
         stream.configure_default_c_allocator()
     }
 

--- a/zlib-rs/src/deflate/algorithm/stored.rs
+++ b/zlib-rs/src/deflate/algorithm/stored.rs
@@ -74,7 +74,7 @@ pub fn deflate_stored(stream: &mut DeflateStream, flush: Flush) -> BlockState {
             let left = Ord::min(left, len);
             let src = &stream.state.window.filled()[stream.state.block_start as usize..];
 
-            unsafe { std::ptr::copy_nonoverlapping(src.as_ptr(), stream.next_out, left) };
+            unsafe { core::ptr::copy_nonoverlapping(src.as_ptr(), stream.next_out, left) };
 
             stream.next_out = stream.next_out.wrapping_add(left);
             stream.avail_out = stream.avail_out.wrapping_sub(left as _);
@@ -233,20 +233,20 @@ fn read_buf_direct_copy(stream: &mut DeflateStream, size: usize) -> usize {
     if stream.state.wrap == 2 {
         // we likely cannot fuse the crc32 and the copy here because the input can be changed by
         // a concurrent thread. Therefore it cannot be converted into a slice!
-        unsafe { std::ptr::copy_nonoverlapping(stream.next_in, output, len) }
+        unsafe { core::ptr::copy_nonoverlapping(stream.next_in, output, len) }
 
-        let data = unsafe { std::slice::from_raw_parts(output, len) };
+        let data = unsafe { core::slice::from_raw_parts(output, len) };
         stream.state.crc_fold.fold(data, 0);
     } else if stream.state.wrap == 1 {
         // we cannot fuse the adler and the copy in our case, because adler32 takes a slice.
         // Another process is allowed to concurrently modify stream.next_in, so we cannot turn it
         // into a rust slice (violates its safety requirements)
-        unsafe { std::ptr::copy_nonoverlapping(stream.next_in, output, len) }
+        unsafe { core::ptr::copy_nonoverlapping(stream.next_in, output, len) }
 
-        let data = unsafe { std::slice::from_raw_parts(output, len) };
+        let data = unsafe { core::slice::from_raw_parts(output, len) };
         stream.adler = crate::adler32::adler32(stream.adler as u32, data) as _;
     } else {
-        unsafe { std::ptr::copy_nonoverlapping(stream.next_in, output, len) }
+        unsafe { core::ptr::copy_nonoverlapping(stream.next_in, output, len) }
     }
 
     stream.next_in = stream.next_in.wrapping_add(len);

--- a/zlib-rs/src/deflate/compare256.rs
+++ b/zlib-rs/src/deflate/compare256.rs
@@ -10,7 +10,7 @@ pub fn compare256_slice(src0: &[u8], src1: &[u8]) -> usize {
 
 fn compare256(src0: &[u8; 256], src1: &[u8; 256]) -> usize {
     #[cfg(all(target_arch = "x86_64", feature = "std"))]
-    if core::is_x86_feature_detected!("avx2") {
+    if std::is_x86_feature_detected!("avx2") {
         debug_assert_eq!(avx2::compare256(src0, src1), rust::compare256(src0, src1));
 
         return avx2::compare256(src0, src1);
@@ -149,7 +149,7 @@ mod neon {
 
     #[test]
     fn test_compare256() {
-        if core::arch::is_aarch64_feature_detected!("neon") {
+        if std::arch::is_aarch64_feature_detected!("neon") {
             let str1 = [b'a'; super::MAX_COMPARE_SIZE];
             let mut str2 = [b'a'; super::MAX_COMPARE_SIZE];
 
@@ -199,7 +199,7 @@ mod avx2 {
 
     #[test]
     fn test_compare256() {
-        if core::arch::is_x86_feature_detected!("avx2") {
+        if std::arch::is_x86_feature_detected!("avx2") {
             let str1 = [b'a'; super::MAX_COMPARE_SIZE];
             let mut str2 = [b'a'; super::MAX_COMPARE_SIZE];
 

--- a/zlib-rs/src/deflate/compare256.rs
+++ b/zlib-rs/src/deflate/compare256.rs
@@ -9,14 +9,14 @@ pub fn compare256_slice(src0: &[u8], src1: &[u8]) -> usize {
 }
 
 fn compare256(src0: &[u8; 256], src1: &[u8; 256]) -> usize {
-    #[cfg(target_arch = "x86_64")]
-    if std::is_x86_feature_detected!("avx2") {
+    #[cfg(all(target_arch = "x86_64", feature = "std"))]
+    if core::is_x86_feature_detected!("avx2") {
         debug_assert_eq!(avx2::compare256(src0, src1), rust::compare256(src0, src1));
 
         return avx2::compare256(src0, src1);
     }
 
-    #[cfg(target_arch = "aarch64")]
+    #[cfg(all(target_arch = "aarch64", feature = "std"))]
     if std::arch::is_aarch64_feature_detected!("neon") {
         debug_assert_eq!(neon::compare256(src0, src1), rust::compare256(src0, src1));
 
@@ -109,13 +109,13 @@ mod rust {
 
 #[cfg(target_arch = "aarch64")]
 mod neon {
-    use std::arch::aarch64::{
+    use core::arch::aarch64::{
         uint8x16_t, veorq_u8, vgetq_lane_u64, vld1q_u8, vreinterpretq_u64_u8,
     };
 
     pub fn compare256(src0: &[u8; 256], src1: &[u8; 256]) -> usize {
-        let src0: &[[u8; 16]; 16] = unsafe { std::mem::transmute(src0) };
-        let src1: &[[u8; 16]; 16] = unsafe { std::mem::transmute(src1) };
+        let src0: &[[u8; 16]; 16] = unsafe { core::mem::transmute(src0) };
+        let src1: &[[u8; 16]; 16] = unsafe { core::mem::transmute(src1) };
 
         let mut len = 0;
 
@@ -149,7 +149,7 @@ mod neon {
 
     #[test]
     fn test_compare256() {
-        if std::arch::is_aarch64_feature_detected!("neon") {
+        if core::arch::is_aarch64_feature_detected!("neon") {
             let str1 = [b'a'; super::MAX_COMPARE_SIZE];
             let mut str2 = [b'a'; super::MAX_COMPARE_SIZE];
 
@@ -167,11 +167,13 @@ mod neon {
 
 #[cfg(target_arch = "x86_64")]
 mod avx2 {
-    use std::arch::x86_64::{__m256i, _mm256_cmpeq_epi8, _mm256_loadu_si256, _mm256_movemask_epi8};
+    use core::arch::x86_64::{
+        __m256i, _mm256_cmpeq_epi8, _mm256_loadu_si256, _mm256_movemask_epi8,
+    };
 
     pub fn compare256(src0: &[u8; 256], src1: &[u8; 256]) -> usize {
-        let src0: &[[u8; 32]; 8] = unsafe { std::mem::transmute(src0) };
-        let src1: &[[u8; 32]; 8] = unsafe { std::mem::transmute(src1) };
+        let src0: &[[u8; 32]; 8] = unsafe { core::mem::transmute(src0) };
+        let src1: &[[u8; 32]; 8] = unsafe { core::mem::transmute(src1) };
 
         let mut len = 0;
 
@@ -197,7 +199,7 @@ mod avx2 {
 
     #[test]
     fn test_compare256() {
-        if std::arch::is_x86_feature_detected!("avx2") {
+        if core::arch::is_x86_feature_detected!("avx2") {
             let str1 = [b'a'; super::MAX_COMPARE_SIZE];
             let mut str2 = [b'a'; super::MAX_COMPARE_SIZE];
 

--- a/zlib-rs/src/deflate/hash_calc.rs
+++ b/zlib-rs/src/deflate/hash_calc.rs
@@ -156,6 +156,12 @@ impl HashCalc for Crc32HashCalc {
     fn hash_calc(h: u32, val: u32) -> u32 {
         unsafe { crate::crc32::acle::__crc32cw(h, val) }
     }
+
+    #[cfg(not(any(target_arch = "x86", target_arch = "x86_64", target_arch = "aarch64")))]
+    fn hash_calc(h: u32, val: u32) -> u32 {
+        assert!(!Self::is_supported());
+        unimplemented!("there is no hardware support on this platform")
+    }
 }
 
 #[cfg(test)]

--- a/zlib-rs/src/deflate/hash_calc.rs
+++ b/zlib-rs/src/deflate/hash_calc.rs
@@ -129,7 +129,7 @@ impl Crc32HashCalc {
             return true;
         }
 
-        #[cfg(target_arch = "aarch64")]
+        #[cfg(all(target_arch = "aarch64", feature = "std"))]
         return std::arch::is_aarch64_feature_detected!("crc");
 
         #[allow(unreachable_code)]
@@ -144,12 +144,12 @@ impl HashCalc for Crc32HashCalc {
 
     #[cfg(target_arch = "x86")]
     fn hash_calc(h: u32, val: u32) -> u32 {
-        unsafe { std::arch::x86::_mm_crc32_u32(h, val) }
+        unsafe { core::arch::x86::_mm_crc32_u32(h, val) }
     }
 
     #[cfg(target_arch = "x86_64")]
     fn hash_calc(h: u32, val: u32) -> u32 {
-        unsafe { std::arch::x86_64::_mm_crc32_u32(h, val) }
+        unsafe { core::arch::x86_64::_mm_crc32_u32(h, val) }
     }
 
     #[cfg(target_arch = "aarch64")]

--- a/zlib-rs/src/deflate/longest_match.rs
+++ b/zlib-rs/src/deflate/longest_match.rs
@@ -65,9 +65,9 @@ fn longest_match_help<const SLOW: bool>(
     let mut offset = best_len - 1;
 
     // we're assuming we can do a fast(ish) unaligned 64-bit read
-    if best_len >= std::mem::size_of::<u32>() {
+    if best_len >= core::mem::size_of::<u32>() {
         offset -= 2;
-        if best_len >= std::mem::size_of::<u64>() {
+        if best_len >= core::mem::size_of::<u64>() {
             offset -= 4;
         }
     }
@@ -156,8 +156,8 @@ fn longest_match_help<const SLOW: bool>(
         // The two pointers must be valid for reads of N bytes.
         #[inline(always)]
         unsafe fn memcmp_n_ptr<const N: usize>(src0: *const u8, src1: *const u8) -> bool {
-            let src0_cmp = std::ptr::read(src0 as *const [u8; N]);
-            let src1_cmp = std::ptr::read(src1 as *const [u8; N]);
+            let src0_cmp = core::ptr::read(src0 as *const [u8; N]);
+            let src1_cmp = core::ptr::read(src1 as *const [u8; N]);
 
             src0_cmp == src1_cmp
         }
@@ -182,7 +182,7 @@ fn longest_match_help<const SLOW: bool>(
             let scan_start = scan_start.as_ptr();
             let scan_end = scan_end.as_ptr();
 
-            if best_len < std::mem::size_of::<u32>() {
+            if best_len < core::mem::size_of::<u32>() {
                 loop {
                     if is_match::<2>(cur_match, mbase_start, mbase_end, scan_start, scan_end) {
                         break;
@@ -190,7 +190,7 @@ fn longest_match_help<const SLOW: bool>(
 
                     goto_next_in_chain!();
                 }
-            } else if best_len >= std::mem::size_of::<u64>() {
+            } else if best_len >= core::mem::size_of::<u64>() {
                 loop {
                     if is_match::<8>(cur_match, mbase_start, mbase_end, scan_start, scan_end) {
                         break;
@@ -236,9 +236,9 @@ fn longest_match_help<const SLOW: bool>(
             }
 
             offset = best_len - 1;
-            if best_len >= std::mem::size_of::<u32>() {
+            if best_len >= core::mem::size_of::<u32>() {
                 offset -= 2;
-                if best_len >= std::mem::size_of::<u64>() {
+                if best_len >= core::mem::size_of::<u64>() {
                     offset -= 4;
                 }
             }

--- a/zlib-rs/src/deflate/pending.rs
+++ b/zlib-rs/src/deflate/pending.rs
@@ -1,4 +1,4 @@
-use std::marker::PhantomData;
+use core::marker::PhantomData;
 
 use crate::allocate::Allocator;
 
@@ -17,7 +17,7 @@ impl<'a> Pending<'a> {
     }
 
     pub fn pending(&self) -> &[u8] {
-        unsafe { std::slice::from_raw_parts(self.out, self.pending) }
+        unsafe { core::slice::from_raw_parts(self.out, self.pending) }
     }
 
     pub(crate) fn remaining(&self) -> usize {
@@ -59,7 +59,7 @@ impl<'a> Pending<'a> {
         );
 
         unsafe {
-            std::ptr::copy_nonoverlapping(buf.as_ptr(), self.out.add(self.pending), buf.len());
+            core::ptr::copy_nonoverlapping(buf.as_ptr(), self.out.add(self.pending), buf.len());
         }
 
         self.pending += buf.len();

--- a/zlib-rs/src/deflate/slide_hash.rs
+++ b/zlib-rs/src/deflate/slide_hash.rs
@@ -110,7 +110,7 @@ mod tests {
     #[test]
     #[cfg(target_arch = "x86_64")]
     fn test_slide_hash_avx2() {
-        if core::arch::is_x86_feature_detected!("avx2") {
+        if std::arch::is_x86_feature_detected!("avx2") {
             let mut input = INPUT;
 
             avx2::slide_hash_chain(&mut input, WSIZE);
@@ -122,7 +122,7 @@ mod tests {
     #[test]
     #[cfg(target_arch = "aarch64")]
     fn test_slide_hash_neon() {
-        if core::arch::is_aarch64_feature_detected!("neon") {
+        if std::arch::is_aarch64_feature_detected!("neon") {
             let mut input = INPUT;
 
             neon::slide_hash_chain(&mut input, WSIZE);

--- a/zlib-rs/src/deflate/slide_hash.rs
+++ b/zlib-rs/src/deflate/slide_hash.rs
@@ -6,12 +6,12 @@ pub fn slide_hash(state: &mut crate::deflate::State) {
 }
 
 fn slide_hash_chain(table: &mut [u16], wsize: u16) {
-    #[cfg(target_arch = "x86_64")]
+    #[cfg(all(target_arch = "x86_64", feature = "std"))]
     if std::is_x86_feature_detected!("avx2") {
         return avx2::slide_hash_chain(table, wsize);
     }
 
-    #[cfg(target_arch = "aarch64")]
+    #[cfg(all(target_arch = "aarch64", feature = "std"))]
     if std::arch::is_aarch64_feature_detected!("neon") {
         return neon::slide_hash_chain(table, wsize);
     }
@@ -29,7 +29,7 @@ mod rust {
 
 #[cfg(target_arch = "aarch64")]
 mod neon {
-    use std::arch::aarch64::{
+    use core::arch::aarch64::{
         uint16x8_t, uint16x8x4_t, vdupq_n_u16, vld1q_u16_x4, vqsubq_u16, vst1q_u16_x4,
     };
 
@@ -59,7 +59,7 @@ mod neon {
 
 #[cfg(target_arch = "x86_64")]
 mod avx2 {
-    use std::arch::x86_64::{
+    use core::arch::x86_64::{
         __m256i, _mm256_loadu_si256, _mm256_set1_epi16, _mm256_storeu_si256, _mm256_subs_epu16,
     };
 
@@ -110,7 +110,7 @@ mod tests {
     #[test]
     #[cfg(target_arch = "x86_64")]
     fn test_slide_hash_avx2() {
-        if std::arch::is_x86_feature_detected!("avx2") {
+        if core::arch::is_x86_feature_detected!("avx2") {
             let mut input = INPUT;
 
             avx2::slide_hash_chain(&mut input, WSIZE);
@@ -122,7 +122,7 @@ mod tests {
     #[test]
     #[cfg(target_arch = "aarch64")]
     fn test_slide_hash_neon() {
-        if std::arch::is_aarch64_feature_detected!("neon") {
+        if core::arch::is_aarch64_feature_detected!("neon") {
             let mut input = INPUT;
 
             neon::slide_hash_chain(&mut input, WSIZE);
@@ -136,7 +136,7 @@ mod tests {
             // pad to a multiple of 32
             let difference = v.len().next_multiple_of(32) - v.len();
             let mut v = v;
-            v.extend(std::iter::repeat(u16::MAX).take(difference));
+            v.extend(core::iter::repeat(u16::MAX).take(difference));
 
 
             let mut a = v.clone();

--- a/zlib-rs/src/deflate/window.rs
+++ b/zlib-rs/src/deflate/window.rs
@@ -1,6 +1,5 @@
-use std::mem::MaybeUninit;
-
 use crate::allocate::Allocator;
+use core::mem::MaybeUninit;
 
 #[derive(Debug)]
 pub struct Window<'a> {
@@ -70,11 +69,11 @@ impl<'a> Window<'a> {
     /// # Safety
     ///
     /// `src` must point to `range.end - range.start` valid (initialized!) bytes
-    pub unsafe fn copy_and_initialize(&mut self, range: std::ops::Range<usize>, src: *const u8) {
+    pub unsafe fn copy_and_initialize(&mut self, range: core::ops::Range<usize>, src: *const u8) {
         let (start, end) = (range.start, range.end);
 
         let dst = self.buf[range].as_mut_ptr() as *mut u8;
-        std::ptr::copy_nonoverlapping(src, dst, end - start);
+        core::ptr::copy_nonoverlapping(src, dst, end - start);
 
         if start >= self.filled {
             self.filled = Ord::max(self.filled, end);
@@ -137,10 +136,11 @@ impl<'a> Window<'a> {
 
     // padding required so that SIMD operations going out-of-bounds are not a problem
     pub fn padding() -> usize {
+        #[cfg(feature = "std")]
         #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-        if is_x86_feature_detected!("pclmulqdq")
-            && is_x86_feature_detected!("sse2")
-            && is_x86_feature_detected!("sse4.1")
+        if std::is_x86_feature_detected!("pclmulqdq")
+            && std::is_x86_feature_detected!("sse2")
+            && std::is_x86_feature_detected!("sse4.1")
         {
             return 8;
         }

--- a/zlib-rs/src/inflate.rs
+++ b/zlib-rs/src/inflate.rs
@@ -1708,6 +1708,15 @@ pub fn init(stream: &mut z_stream, config: InflateConfig) -> ReturnCode {
         stream.configure_default_rust_allocator()
     }
 
+    #[cfg(not(feature = "alloc"))]
+    if cfg!(test) && stream.zalloc.is_none() || stream.zfree.is_none() {
+        stream.configure_default_c_allocator()
+    }
+
+    if stream.zalloc.is_none() || stream.zfree.is_none() {
+        return ReturnCode::StreamError;
+    }
+
     let mut state = State::new(&[], ReadBuf::new(&mut []));
 
     // TODO this can change depending on the used/supported SIMD instructions

--- a/zlib-rs/src/inflate.rs
+++ b/zlib-rs/src/inflate.rs
@@ -1703,13 +1703,13 @@ pub fn init(stream: &mut z_stream, config: InflateConfig) -> ReturnCode {
     // for safety we must really make sure that alloc and free are consistent
     // this is a (slight) deviation from stock zlib. In this crate we pick the rust
     // allocator as the default, but `libz-rs-sys` configures the C allocator
-    #[cfg(feature = "alloc")]
+    #[cfg(feature = "rust-allocator")]
     if stream.zalloc.is_none() || stream.zfree.is_none() {
         stream.configure_default_rust_allocator()
     }
 
-    #[cfg(not(feature = "alloc"))]
-    if cfg!(test) && stream.zalloc.is_none() || stream.zfree.is_none() {
+    #[cfg(feature = "c-allocator")]
+    if stream.zalloc.is_none() || stream.zfree.is_none() {
         stream.configure_default_c_allocator()
     }
 

--- a/zlib-rs/src/inflate/inftrees.rs
+++ b/zlib-rs/src/inflate/inftrees.rs
@@ -275,7 +275,7 @@ mod test {
         let table = [Code::default(); crate::ENOUGH_DISTS];
 
         let mut work = [0; 16];
-        let mut lens: [_; 16] = std::array::from_fn(|i| (i + 1) as u16);
+        let mut lens: [_; 16] = core::array::from_fn(|i| (i + 1) as u16);
         lens[15] = 15;
 
         let mut next = table;
@@ -315,7 +315,7 @@ mod test {
         let bits = 9;
         inflate_table(CodeType::Lens, &lens, 288, &mut next, bits, work);
 
-        std::array::from_fn(|i| {
+        core::array::from_fn(|i| {
             let mut code = next[i];
 
             code.op = if i & 0b0111_1111 == 99 { 64 } else { code.op };

--- a/zlib-rs/src/inflate/window.rs
+++ b/zlib-rs/src/inflate/window.rs
@@ -3,7 +3,7 @@ use crate::{
     allocate::Allocator,
     crc32::Crc32Fold,
 };
-use std::mem::MaybeUninit;
+use core::mem::MaybeUninit;
 
 // translation guide:
 //

--- a/zlib-rs/src/lib.rs
+++ b/zlib-rs/src/lib.rs
@@ -1,7 +1,7 @@
-#![doc = include_str!("../README.md")]
-#![cfg_attr(not(any(test, feature = "alloc")), no_std)]
+#![doc = core::include_str!("../README.md")]
+#![cfg_attr(not(any(test, feature = "rust-allocator")), no_std)]
 
-#[cfg(feature = "alloc")]
+#[cfg(any(feature = "rust-allocator", feature = "c-allocator"))]
 extern crate alloc;
 
 mod adler32;

--- a/zlib-rs/src/lib.rs
+++ b/zlib-rs/src/lib.rs
@@ -1,4 +1,8 @@
 #![doc = include_str!("../README.md")]
+#![cfg_attr(not(any(test, feature = "alloc")), no_std)]
+
+#[cfg(feature = "alloc")]
+extern crate alloc;
 
 mod adler32;
 pub mod allocate;


### PR DESCRIPTION
As promised:
This PR adds `no_std` support to `zlib-rs`, by adding two new feature flags `std` and `alloc` that hide related functionality behind them (enabled by default).

I also had to disable the auto-detection of features which is not yet exposed through feature flags.