### PR TITLE
Adjust MSRV to 1.75

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -28,6 +28,10 @@ jobs:
             os: ubuntu-latest
             features: ""
             target: "x86_64-unknown-linux-gnu"
+          - rust: msrv
+            os: ubuntu-latest
+            features: ""
+            target: "x86_64-unknown-linux-gnu"
           - rust: beta
             os: ubuntu-latest
             features: ""

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ homepage = "https://github.com/memorysafety/zlib-rs"
 readme = "./README.md"
 description = "A memory-safe zlib implementation written in rust"
 publish = true
-rust-version = "1.73" # MSRV
+rust-version = "1.75" # MSRV
 
 [profile.release]
 debug = true


### PR DESCRIPTION
Current main fails to build with 1.73:

```
$ cargo +1.73 check
    Checking libc v0.2.154
   Compiling libz-sys v1.1.16
    Checking cfg-if v1.0.0
    Checking zlib-rs v0.1.1 (/home/jbp/zlib-rs/zlib-rs)
    Checking libloading v0.8.3
error[E0658]: mutable references are not allowed in constant functions
  --> zlib-rs/src/deflate/algorithm/mod.rs:58:9
   |
58 |         func: CompressFunc,
   |         ^^^^
   |
   = note: see issue #57349 <https://github.com/rust-lang/rust/issues/57349> for more information

For more information about this error, try `rustc --explain E0658`.
error: could not compile `zlib-rs` (lib) due to previous error
warning: build failed, waiting for other jobs to finish...
```