### PR TITLE
separate flush into `DeflateFlush` and `InflateFlush`

### DIFF
--- a/fuzz/fuzz_targets/end_to_end.rs
+++ b/fuzz/fuzz_targets/end_to_end.rs
@@ -3,7 +3,7 @@ use libfuzzer_sys::fuzz_target;
 
 use zlib_rs::deflate::DeflateConfig;
 use zlib_rs::inflate::InflateConfig;
-use zlib_rs::{Flush, ReturnCode};
+use zlib_rs::{DeflateFlush, InflateFlush, ReturnCode};
 
 use std::ffi::c_uint;
 
@@ -138,9 +138,9 @@ fn compress_slice_ng<'a>(
         }
 
         let flush = if source_len > 0 {
-            Flush::NoFlush
+            DeflateFlush::NoFlush
         } else {
-            Flush::Finish
+            DeflateFlush::Finish
         };
 
         let err = unsafe { libz_ng_sys::deflate(&mut stream, flush as i32) };
@@ -226,7 +226,7 @@ fn uncompress_slice_ng<'a>(
             len -= stream.avail_in as u64;
         }
 
-        let err = unsafe { libz_ng_sys::inflate(&mut stream, Flush::NoFlush as _) };
+        let err = unsafe { libz_ng_sys::inflate(&mut stream, InflateFlush::NoFlush as _) };
         let err = ReturnCode::from(err);
 
         if err != ReturnCode::Ok as _ {

--- a/libz-rs-sys/examples/compress.rs
+++ b/libz-rs-sys/examples/compress.rs
@@ -5,7 +5,7 @@ use std::{collections::hash_map::DefaultHasher, env::temp_dir, hash::Hash};
 // we use the libz_sys but configure zlib-ng in zlib compat mode
 use libz_sys as libz_ng_sys;
 
-use zlib_rs::{deflate::DeflateConfig, Flush, ReturnCode};
+use zlib_rs::{deflate::DeflateConfig, DeflateFlush, ReturnCode};
 
 use std::ffi::{c_int, c_uint};
 
@@ -172,9 +172,9 @@ fn compress_rs(
         }
 
         let flush = if source_len > 0 {
-            Flush::NoFlush
+            DeflateFlush::NoFlush
         } else {
-            Flush::Finish
+            DeflateFlush::Finish
         };
 
         let err = unsafe { deflate(&mut stream, flush as i32) };
@@ -253,9 +253,9 @@ fn compress_ng(
         }
 
         let flush = if source_len > 0 {
-            Flush::NoFlush
+            DeflateFlush::NoFlush
         } else {
-            Flush::Finish
+            DeflateFlush::Finish
         };
 
         let err = unsafe { deflate(&mut stream, flush as i32) };

--- a/libz-rs-sys/src/lib.rs
+++ b/libz-rs-sys/src/lib.rs
@@ -27,7 +27,7 @@ use core::ffi::{c_char, c_int, c_long, c_uchar, c_uint, c_ulong, c_void};
 use zlib_rs::{
     deflate::{DeflateConfig, DeflateStream, Method, Strategy},
     inflate::{InflateConfig, InflateStream},
-    Flush, ReturnCode,
+    DeflateFlush, InflateFlush, ReturnCode,
 };
 
 pub use zlib_rs::c_api::*;
@@ -130,7 +130,7 @@ pub unsafe extern "C" fn uncompress(
 
 pub unsafe extern "C" fn inflate(strm: *mut z_stream, flush: i32) -> i32 {
     if let Some(stream) = InflateStream::from_stream_mut(strm) {
-        let flush = crate::Flush::try_from(flush).unwrap_or_default();
+        let flush = InflateFlush::try_from(flush).unwrap_or_default();
         zlib_rs::inflate::inflate(stream, flush) as _
     } else {
         ReturnCode::StreamError as _
@@ -343,7 +343,7 @@ pub unsafe extern "C" fn inflateCodesUsed(_strm: *mut z_stream) -> c_ulong {
 
 pub unsafe extern "C" fn deflate(strm: *mut z_stream, flush: i32) -> i32 {
     if let Some(stream) = DeflateStream::from_stream_mut(strm) {
-        match crate::Flush::try_from(flush) {
+        match DeflateFlush::try_from(flush) {
             Ok(flush) => zlib_rs::deflate::deflate(stream, flush) as _,
             Err(()) => ReturnCode::StreamError as _,
         }

--- a/libz-rs-sys/src/tests/deflate.rs
+++ b/libz-rs-sys/src/tests/deflate.rs
@@ -15,7 +15,7 @@ use zlib_rs::{
     c_api::Z_BEST_COMPRESSION,
     deflate::{DeflateConfig, Method, Strategy},
     inflate::InflateConfig,
-    Flush, ReturnCode,
+    DeflateFlush, ReturnCode,
 };
 
 const VERSION: *const c_char = libz_rs_sys::zlibVersion();
@@ -104,12 +104,12 @@ pub mod quick {
         stream.avail_in = 554;
         stream.avail_out = 31;
 
-        let err = unsafe { deflate(&mut stream, Flush::Finish as i32) };
+        let err = unsafe { deflate(&mut stream, DeflateFlush::Finish as i32) };
         assert_eq!(ReturnCode::from(err), ReturnCode::Ok);
 
         stream.avail_in = 0;
         stream.avail_out = 498;
-        let err = unsafe { deflate(&mut stream, Flush::Finish as i32) };
+        let err = unsafe { deflate(&mut stream, DeflateFlush::Finish as i32) };
         assert_eq!(ReturnCode::from(err), ReturnCode::StreamEnd);
 
         let err = unsafe { deflateEnd(&mut stream) };
@@ -200,7 +200,7 @@ pub mod quick {
                 stream.avail_out = 38;
             }
 
-            let err = unsafe { deflate(&mut stream, Flush::Finish as i32) };
+            let err = unsafe { deflate(&mut stream, DeflateFlush::Finish as i32) };
             if ReturnCode::from(err) == ReturnCode::StreamEnd {
                 break;
             }
@@ -298,7 +298,7 @@ pub mod quick {
                 stream.avail_out = 38;
             }
 
-            let err = unsafe { deflate(&mut stream, Flush::Finish as i32) };
+            let err = unsafe { deflate(&mut stream, DeflateFlush::Finish as i32) };
             if ReturnCode::from(err) == ReturnCode::StreamEnd {
                 break;
             }
@@ -396,7 +396,7 @@ pub mod quick {
                 stream.avail_out = 38;
             }
 
-            let err = unsafe { deflate(&mut stream, Flush::Finish as i32) };
+            let err = unsafe { deflate(&mut stream, DeflateFlush::Finish as i32) };
             if ReturnCode::from(err) == ReturnCode::StreamEnd {
                 break;
             }
@@ -777,7 +777,7 @@ fn test_compress_param() {
         stream.next_in = input.as_ptr() as *mut u8;
         stream.avail_in = offset as _;
 
-        let err = libz_rs_sys::deflate(stream, Flush::NoFlush as i32);
+        let err = libz_rs_sys::deflate(stream, DeflateFlush::NoFlush as i32);
         assert_eq!(err, 0);
 
         let err = libz_rs_sys::deflateParams(stream, 8, Strategy::Rle as i32);
@@ -787,7 +787,7 @@ fn test_compress_param() {
 
         stream.avail_in = (input.len() - offset) as _;
 
-        let err = libz_rs_sys::deflate(stream, Flush::Finish as i32);
+        let err = libz_rs_sys::deflate(stream, DeflateFlush::Finish as i32);
         assert_eq!(err, ReturnCode::StreamEnd as i32);
 
         let err = libz_rs_sys::deflateEnd(stream);
@@ -831,7 +831,7 @@ fn test_compress_param() {
         stream.next_in = input.as_ptr() as *mut u8;
         stream.avail_in = offset as _;
 
-        let err = libz_ng_sys::deflate(stream, Flush::NoFlush as i32);
+        let err = libz_ng_sys::deflate(stream, DeflateFlush::NoFlush as i32);
         assert_eq!(err, 0);
 
         let err = libz_ng_sys::deflateParams(stream, 8, Strategy::Rle as i32);
@@ -841,7 +841,7 @@ fn test_compress_param() {
 
         stream.avail_in = (input.len() - offset) as _;
 
-        let err = libz_ng_sys::deflate(stream, Flush::Finish as i32);
+        let err = libz_ng_sys::deflate(stream, DeflateFlush::Finish as i32);
         assert_eq!(err, ReturnCode::StreamEnd as i32);
 
         let err = libz_ng_sys::deflateEnd(stream);
@@ -895,7 +895,7 @@ fn test_dict_deflate() {
         strm.next_in = HELLO.as_ptr() as *mut u8;
         strm.avail_in = HELLO.len() as _;
 
-        let err = deflate(strm, Flush::Finish as i32);
+        let err = deflate(strm, DeflateFlush::Finish as i32);
         assert_eq!(ReturnCode::from(err), ReturnCode::StreamEnd);
 
         let err = deflateEnd(strm);
@@ -936,7 +936,7 @@ fn test_dict_deflate() {
         strm.next_in = HELLO.as_ptr() as *mut u8;
         strm.avail_in = HELLO.len() as _;
 
-        let err = libz_ng_sys::deflate(strm, Flush::Finish as i32);
+        let err = libz_ng_sys::deflate(strm, DeflateFlush::Finish as i32);
         assert_eq!(ReturnCode::from(err), ReturnCode::StreamEnd);
 
         let err = libz_ng_sys::deflateEnd(strm);
@@ -1019,7 +1019,7 @@ fn test_deflate_prime() {
         strm.next_out = compr.as_mut_ptr();
         strm.avail_out = compr.len() as _;
 
-        err = libz_rs_sys::deflate(strm, Flush::Finish as i32);
+        err = libz_rs_sys::deflate(strm, DeflateFlush::Finish as i32);
         assert_eq!(err, ReturnCode::StreamEnd as i32);
 
         dbg!(strm.total_out);
@@ -1064,7 +1064,7 @@ fn test_deflate_prime() {
 
         // the crc checksum is not actually in the buffer, so the check of the checksum will error
         // out with a BufError because there is insufficient input.
-        let err = libz_rs_sys::inflate(strm, Flush::Finish as i32);
+        let err = libz_rs_sys::inflate(strm, DeflateFlush::Finish as i32);
         assert_eq!(ReturnCode::from(err), ReturnCode::BufError);
         assert_eq!(&uncompr[..strm.total_out as usize], HELLO.as_bytes())
     }
@@ -1119,7 +1119,7 @@ fn small_window() {
         strm.next_out = compr.as_mut_ptr();
         strm.avail_out = compr.len() as _;
 
-        let err = deflate(strm, Flush::Finish as i32);
+        let err = deflate(strm, DeflateFlush::Finish as i32);
         assert_eq!(ReturnCode::from(err), ReturnCode::StreamEnd);
 
         let err = deflateEnd(strm);
@@ -1152,7 +1152,7 @@ fn small_window() {
         strm.next_out = plain_again.as_mut_ptr();
         strm.avail_out = plain_again.len() as _;
 
-        let err = libz_rs_sys::inflate(strm, Flush::NoFlush as i32);
+        let err = libz_rs_sys::inflate(strm, DeflateFlush::NoFlush as i32);
         assert_eq!(ReturnCode::from(err), ReturnCode::StreamEnd);
 
         let err = libz_rs_sys::inflateEnd(strm);
@@ -1193,7 +1193,7 @@ fn small_window() {
         strm.next_out = compr.as_mut_ptr();
         strm.avail_out = compr.len() as _;
 
-        let err = libz_ng_sys::deflate(strm, Flush::Finish as i32);
+        let err = libz_ng_sys::deflate(strm, DeflateFlush::Finish as i32);
         assert_eq!(ReturnCode::from(err), ReturnCode::StreamEnd);
 
         let err = libz_ng_sys::deflateEnd(strm);
@@ -1226,7 +1226,7 @@ fn small_window() {
         strm.next_out = plain_again.as_mut_ptr();
         strm.avail_out = plain_again.len() as _;
 
-        let err = libz_ng_sys::inflate(strm, Flush::NoFlush as i32);
+        let err = libz_ng_sys::inflate(strm, DeflateFlush::NoFlush as i32);
         assert_eq!(ReturnCode::from(err), ReturnCode::StreamEnd);
 
         let err = libz_ng_sys::inflateEnd(strm);
@@ -1272,7 +1272,7 @@ fn test_deflate_pending() {
         for (_, _) in it_in.zip(&mut it_out) {
             strm.avail_in = 1;
             strm.avail_out = 1;
-            let err = deflate(strm, Flush::NoFlush as i32);
+            let err = deflate(strm, DeflateFlush::NoFlush as i32);
             assert_eq!(err, 0);
         }
 
@@ -1309,7 +1309,7 @@ fn test_deflate_pending() {
     }
 }
 
-/// test deflate() with Flush::Full
+/// test deflate() with DeflateFlush::Full
 #[test]
 fn test_flush() {
     let config = DeflateConfig::default();
@@ -1341,14 +1341,14 @@ fn test_flush() {
         stream.avail_in = 3;
         stream.avail_out = compr.len() as _;
 
-        let err = libz_rs_sys::deflate(stream, Flush::FullFlush as i32);
+        let err = libz_rs_sys::deflate(stream, DeflateFlush::FullFlush as i32);
         assert_eq!(ReturnCode::from(err), ReturnCode::Ok);
 
         // force an error in the first compressed block
         compr[3] += 1;
         stream.avail_in = (HELLO.len() - 3) as _;
 
-        let err = libz_rs_sys::deflate(stream, Flush::Finish as i32);
+        let err = libz_rs_sys::deflate(stream, DeflateFlush::Finish as i32);
         assert_eq!(ReturnCode::from(err), ReturnCode::StreamEnd);
 
         let err = libz_rs_sys::deflateEnd(stream);
@@ -1383,14 +1383,14 @@ fn test_sync(compr: &[u8]) {
         stream.next_out = uncompr.as_mut_ptr();
         stream.avail_out = uncompr.len() as _;
 
-        let err = libz_rs_sys::inflate(stream, Flush::NoFlush as i32);
+        let err = libz_rs_sys::inflate(stream, DeflateFlush::NoFlush as i32);
         assert_eq!(ReturnCode::from(err), ReturnCode::Ok);
 
         stream.avail_in = (compr.len() - 2) as _; // read all compressed data
         let err = libz_rs_sys::inflateSync(stream); // but skip the damaged part (at index 3)
         assert_eq!(ReturnCode::from(err), ReturnCode::Ok);
 
-        let err = libz_rs_sys::inflate(stream, Flush::Finish as i32);
+        let err = libz_rs_sys::inflate(stream, DeflateFlush::Finish as i32);
         assert_eq!(ReturnCode::from(err), ReturnCode::StreamEnd);
 
         let err = libz_rs_sys::inflateEnd(stream);
@@ -1525,13 +1525,13 @@ fn test_deflate_copy() {
             strm.avail_in = 1;
             strm.avail_out = 1;
 
-            let err = libz_rs_sys::deflate(strm, Flush::NoFlush as i32);
+            let err = libz_rs_sys::deflate(strm, DeflateFlush::NoFlush as i32);
             assert_eq!(err, 0);
         }
 
         loop {
             strm.avail_out = 1;
-            let err = libz_rs_sys::deflate(strm, Flush::Finish as i32);
+            let err = libz_rs_sys::deflate(strm, DeflateFlush::Finish as i32);
 
             if ReturnCode::from(err) == ReturnCode::StreamEnd {
                 break;

--- a/libz-rs-sys/src/tests/inflate.rs
+++ b/libz-rs-sys/src/tests/inflate.rs
@@ -239,7 +239,7 @@ fn gzip_header_check() {
     stream.avail_out = len as _;
     stream.next_out = out.as_mut_ptr();
 
-    let ret = unsafe { inflate(&mut stream, Flush::NoFlush as _) };
+    let ret = unsafe { inflate(&mut stream, InflateFlush::NoFlush as _) };
 
     if let Some(err) = err {
         if err != 9 {
@@ -331,7 +331,7 @@ fn inf(input: &[u8], _what: &str, step: usize, win: i32, len: usize, err: c_int)
         stream.avail_out = len as _;
         stream.next_out = out.as_mut_ptr();
 
-        let ret = unsafe { inflate(&mut stream, Flush::NoFlush as _) };
+        let ret = unsafe { inflate(&mut stream, InflateFlush::NoFlush as _) };
 
         if let Some(err) = err {
             assert_eq!(ret, err)
@@ -355,7 +355,7 @@ fn inf(input: &[u8], _what: &str, step: usize, win: i32, len: usize, err: c_int)
             let ret = unsafe { inflateSetDictionary(&mut stream, out.as_ptr(), 0) };
             assert_eq!(ret, Z_OK);
 
-            let ret = unsafe { inflate(&mut stream, Flush::NoFlush as _) };
+            let ret = unsafe { inflate(&mut stream, InflateFlush::NoFlush as _) };
             assert_eq!(ret, Z_BUF_ERROR);
         }
 
@@ -463,9 +463,9 @@ fn cover_wrap() {
     strm.avail_out = 1;
     strm.next_out = (&mut ret) as *mut _ as *mut u8;
     mem_limit(&mut strm, 1);
-    ret = unsafe { inflate(&mut strm, Flush::NoFlush as _) };
+    ret = unsafe { inflate(&mut strm, InflateFlush::NoFlush as _) };
     assert_eq!(ret, Z_MEM_ERROR);
-    ret = unsafe { inflate(&mut strm, Flush::NoFlush as _) };
+    ret = unsafe { inflate(&mut strm, InflateFlush::NoFlush as _) };
     assert_eq!(ret, Z_MEM_ERROR);
     mem_limit(&mut strm, 0);
 
@@ -487,7 +487,7 @@ fn cover_wrap() {
     ret = unsafe { inflateSync(&mut strm) };
     assert_eq!(ret, Z_DATA_ERROR);
 
-    ret = unsafe { inflate(&mut strm, Flush::NoFlush as _) };
+    ret = unsafe { inflate(&mut strm, InflateFlush::NoFlush as _) };
     assert_eq!(ret, Z_STREAM_ERROR);
 
     let mut input = [0u8, 0, 0xFF, 0xFF];
@@ -664,7 +664,7 @@ fn try_inflate(input: &[u8], err: c_int) -> c_int {
         strm.avail_out = size as _;
         strm.next_out = out.as_mut_ptr();
 
-        ret = unsafe { inflate(&mut strm, Flush::Trees as _) };
+        ret = unsafe { inflate(&mut strm, InflateFlush::Trees as _) };
         assert!(!matches!(ret, Z_STREAM_ERROR | Z_MEM_ERROR));
 
         if matches!(ret, Z_DATA_ERROR | Z_NEED_DICT) {
@@ -1264,12 +1264,12 @@ fn gzip_chunked(chunk_size: usize) {
         stream.next_in = chunk.as_ptr() as *mut u8;
         stream.avail_in = chunk.len() as _;
 
-        let err = unsafe { deflate(stream, Flush::NoFlush as _) };
+        let err = unsafe { deflate(stream, InflateFlush::NoFlush as _) };
 
         assert_eq!(err, ReturnCode::Ok as i32, "{:?}", stream.msg);
     }
 
-    let err = unsafe { libz_rs_sys::deflate(stream, Flush::Finish as _) };
+    let err = unsafe { libz_rs_sys::deflate(stream, InflateFlush::Finish as _) };
     assert_eq!(ReturnCode::from(err), ReturnCode::StreamEnd);
 
     let output_rs = &mut output_rs[..stream.total_out as usize];
@@ -1331,7 +1331,7 @@ fn gzip_chunked(chunk_size: usize) {
             stream.next_in = chunk.as_mut_ptr();
             stream.avail_in = chunk.len() as _;
 
-            let err = unsafe { inflate(stream, Flush::NoFlush as _) };
+            let err = unsafe { inflate(stream, InflateFlush::NoFlush as _) };
 
             if err == ReturnCode::StreamEnd as i32 {
                 break;
@@ -1384,7 +1384,7 @@ fn chunked_output_rs() {
     stream.next_out = output.as_mut_ptr();
     stream.avail_out = 32;
 
-    let err = unsafe { inflate(stream, Flush::NoFlush as _) };
+    let err = unsafe { inflate(stream, InflateFlush::NoFlush as _) };
     assert_eq!(ReturnCode::from(err), ReturnCode::Ok);
 
     assert_eq!(stream.avail_out, 0);
@@ -1392,7 +1392,7 @@ fn chunked_output_rs() {
 
     stream.avail_out = 1;
 
-    let err = unsafe { inflate(stream, Flush::Finish as _) };
+    let err = unsafe { inflate(stream, InflateFlush::Finish as _) };
     assert_eq!(ReturnCode::from(err), ReturnCode::StreamEnd);
 
     assert_eq!(stream.total_out, 33);

--- a/zlib-rs/src/deflate/algorithm/fast.rs
+++ b/zlib-rs/src/deflate/algorithm/fast.rs
@@ -4,10 +4,10 @@ use crate::{
     deflate::{
         fill_window, BlockState, DeflateStream, MIN_LOOKAHEAD, STD_MIN_MATCH, WANT_MIN_MATCH,
     },
-    flush_block, Flush,
+    flush_block, DeflateFlush,
 };
 
-pub fn deflate_fast(stream: &mut DeflateStream, flush: Flush) -> BlockState {
+pub fn deflate_fast(stream: &mut DeflateStream, flush: DeflateFlush) -> BlockState {
     let mut bflush; /* set if current block must be flushed */
     let mut dist;
     let mut match_len = 0;
@@ -19,7 +19,7 @@ pub fn deflate_fast(stream: &mut DeflateStream, flush: Flush) -> BlockState {
         // string following the next match.
         if stream.state.lookahead < MIN_LOOKAHEAD {
             fill_window(stream);
-            if stream.state.lookahead < MIN_LOOKAHEAD && flush == Flush::NoFlush {
+            if stream.state.lookahead < MIN_LOOKAHEAD && flush == DeflateFlush::NoFlush {
                 return BlockState::NeedMore;
             }
             if stream.state.lookahead == 0 {
@@ -96,7 +96,7 @@ pub fn deflate_fast(stream: &mut DeflateStream, flush: Flush) -> BlockState {
         STD_MIN_MATCH - 1
     };
 
-    if flush == Flush::Finish {
+    if flush == DeflateFlush::Finish {
         flush_block!(stream, true);
         return BlockState::FinishDone;
     }

--- a/zlib-rs/src/deflate/algorithm/huff.rs
+++ b/zlib-rs/src/deflate/algorithm/huff.rs
@@ -2,10 +2,10 @@
 
 use crate::{
     deflate::{fill_window, BlockState, DeflateStream},
-    flush_block, Flush,
+    flush_block, DeflateFlush,
 };
 
-pub fn deflate_huff(stream: &mut DeflateStream, flush: Flush) -> BlockState {
+pub fn deflate_huff(stream: &mut DeflateStream, flush: DeflateFlush) -> BlockState {
     loop {
         /* Make sure that we have a literal to write. */
         if stream.state.lookahead == 0 {
@@ -13,7 +13,7 @@ pub fn deflate_huff(stream: &mut DeflateStream, flush: Flush) -> BlockState {
 
             if stream.state.lookahead == 0 {
                 match flush {
-                    Flush::NoFlush => return BlockState::NeedMore,
+                    DeflateFlush::NoFlush => return BlockState::NeedMore,
                     _ => break, /* flush the current block */
                 }
             }
@@ -32,7 +32,7 @@ pub fn deflate_huff(stream: &mut DeflateStream, flush: Flush) -> BlockState {
 
     stream.state.insert = 0;
 
-    if flush == Flush::Finish {
+    if flush == DeflateFlush::Finish {
         flush_block!(stream, true);
         return BlockState::FinishDone;
     }

--- a/zlib-rs/src/deflate/algorithm/medium.rs
+++ b/zlib-rs/src/deflate/algorithm/medium.rs
@@ -4,10 +4,10 @@ use crate::{
     deflate::{
         fill_window, BlockState, DeflateStream, State, MIN_LOOKAHEAD, STD_MIN_MATCH, WANT_MIN_MATCH,
     },
-    flush_block, Flush,
+    flush_block, DeflateFlush,
 };
 
-pub fn deflate_medium(stream: &mut DeflateStream, flush: Flush) -> BlockState {
+pub fn deflate_medium(stream: &mut DeflateStream, flush: DeflateFlush) -> BlockState {
     let mut state = &mut stream.state;
 
     // For levels below 5, don't check the next position for a better match
@@ -37,7 +37,7 @@ pub fn deflate_medium(stream: &mut DeflateStream, flush: Flush) -> BlockState {
         if stream.state.lookahead < MIN_LOOKAHEAD {
             fill_window(stream);
 
-            if stream.state.lookahead < MIN_LOOKAHEAD && flush == Flush::NoFlush {
+            if stream.state.lookahead < MIN_LOOKAHEAD && flush == DeflateFlush::NoFlush {
                 return BlockState::NeedMore;
             }
 
@@ -158,7 +158,7 @@ pub fn deflate_medium(stream: &mut DeflateStream, flush: Flush) -> BlockState {
 
     stream.state.insert = Ord::min(stream.state.strstart, STD_MIN_MATCH - 1);
 
-    if flush == Flush::Finish {
+    if flush == DeflateFlush::Finish {
         flush_block!(stream, true);
         return BlockState::FinishDone;
     }

--- a/zlib-rs/src/deflate/algorithm/mod.rs
+++ b/zlib-rs/src/deflate/algorithm/mod.rs
@@ -1,6 +1,6 @@
 use crate::{
     deflate::{BlockState, DeflateStream, Strategy},
-    Flush,
+    DeflateFlush,
 };
 
 use self::{huff::deflate_huff, rle::deflate_rle, stored::deflate_stored};
@@ -27,7 +27,7 @@ macro_rules! flush_block {
     };
 }
 
-pub fn run(stream: &mut DeflateStream, flush: Flush) -> BlockState {
+pub fn run(stream: &mut DeflateStream, flush: DeflateFlush) -> BlockState {
     match stream.state.strategy {
         _ if stream.state.level == 0 => deflate_stored(stream, flush),
         Strategy::HuffmanOnly => deflate_huff(stream, flush),
@@ -38,7 +38,7 @@ pub fn run(stream: &mut DeflateStream, flush: Flush) -> BlockState {
     }
 }
 
-type CompressFunc = fn(&mut DeflateStream, flush: Flush) -> BlockState;
+type CompressFunc = fn(&mut DeflateStream, flush: DeflateFlush) -> BlockState;
 
 #[allow(unused)]
 pub struct Config {

--- a/zlib-rs/src/deflate/algorithm/quick.rs
+++ b/zlib-rs/src/deflate/algorithm/quick.rs
@@ -5,7 +5,7 @@ use crate::{
         fill_window, flush_pending, BlockState, BlockType, DeflateStream, State, StaticTreeDesc,
         MIN_LOOKAHEAD, STD_MAX_MATCH, STD_MIN_MATCH, WANT_MIN_MATCH,
     },
-    Flush,
+    DeflateFlush,
 };
 
 #[inline(always)]
@@ -13,10 +13,10 @@ fn memcmp_n_slice<const N: usize>(src0: &[u8], src1: &[u8]) -> bool {
     src0[..N] != src1[..N]
 }
 
-pub fn deflate_quick(stream: &mut DeflateStream, flush: Flush) -> BlockState {
+pub fn deflate_quick(stream: &mut DeflateStream, flush: DeflateFlush) -> BlockState {
     let mut state = &mut stream.state;
 
-    let last = matches!(flush, Flush::Finish);
+    let last = matches!(flush, DeflateFlush::Finish);
 
     macro_rules! quick_start_block {
         () => {
@@ -81,7 +81,7 @@ pub fn deflate_quick(stream: &mut DeflateStream, flush: Flush) -> BlockState {
             fill_window(stream);
             state = &mut stream.state;
 
-            if state.lookahead < MIN_LOOKAHEAD && matches!(flush, Flush::NoFlush) {
+            if state.lookahead < MIN_LOOKAHEAD && matches!(flush, DeflateFlush::NoFlush) {
                 return BlockState::NeedMore;
             }
             if state.lookahead == 0 {

--- a/zlib-rs/src/deflate/algorithm/rle.rs
+++ b/zlib-rs/src/deflate/algorithm/rle.rs
@@ -5,10 +5,10 @@ use crate::{
         compare256::compare256_rle_slice, fill_window, BlockState, DeflateStream, MIN_LOOKAHEAD,
         STD_MAX_MATCH, STD_MIN_MATCH,
     },
-    flush_block, Flush,
+    flush_block, DeflateFlush,
 };
 
-pub fn deflate_rle(stream: &mut DeflateStream, flush: Flush) -> BlockState {
+pub fn deflate_rle(stream: &mut DeflateStream, flush: DeflateFlush) -> BlockState {
     let mut match_len = 0;
     let mut bflush;
 
@@ -19,7 +19,7 @@ pub fn deflate_rle(stream: &mut DeflateStream, flush: Flush) -> BlockState {
         // string following the next match.
         if stream.state.lookahead < MIN_LOOKAHEAD {
             fill_window(stream);
-            if stream.state.lookahead < MIN_LOOKAHEAD && flush == Flush::NoFlush {
+            if stream.state.lookahead < MIN_LOOKAHEAD && flush == DeflateFlush::NoFlush {
                 return BlockState::NeedMore;
             }
             if stream.state.lookahead == 0 {
@@ -70,7 +70,7 @@ pub fn deflate_rle(stream: &mut DeflateStream, flush: Flush) -> BlockState {
 
     stream.state.insert = 0;
 
-    if flush == Flush::Finish {
+    if flush == DeflateFlush::Finish {
         flush_block!(stream, true);
         return BlockState::FinishDone;
     }

--- a/zlib-rs/src/deflate/algorithm/slow.rs
+++ b/zlib-rs/src/deflate/algorithm/slow.rs
@@ -5,10 +5,10 @@ use crate::{
         fill_window, flush_block_only, BlockState, DeflateStream, Strategy, MIN_LOOKAHEAD,
         STD_MIN_MATCH, WANT_MIN_MATCH,
     },
-    flush_block, Flush,
+    flush_block, DeflateFlush,
 };
 
-pub fn deflate_slow(stream: &mut DeflateStream, flush: Flush) -> BlockState {
+pub fn deflate_slow(stream: &mut DeflateStream, flush: DeflateFlush) -> BlockState {
     let mut hash_head; /* head of hash chain */
     let mut bflush; /* set if current block must be flushed */
     let mut dist;
@@ -29,7 +29,7 @@ pub fn deflate_slow(stream: &mut DeflateStream, flush: Flush) -> BlockState {
          */
         if stream.state.lookahead < MIN_LOOKAHEAD {
             fill_window(stream);
-            if stream.state.lookahead < MIN_LOOKAHEAD && flush == Flush::NoFlush {
+            if stream.state.lookahead < MIN_LOOKAHEAD && flush == DeflateFlush::NoFlush {
                 return BlockState::NeedMore;
             }
 
@@ -135,7 +135,7 @@ pub fn deflate_slow(stream: &mut DeflateStream, flush: Flush) -> BlockState {
         }
     }
 
-    assert_ne!(flush, Flush::NoFlush, "no flush?");
+    assert_ne!(flush, DeflateFlush::NoFlush, "no flush?");
 
     let state = &mut stream.state;
 
@@ -147,7 +147,7 @@ pub fn deflate_slow(stream: &mut DeflateStream, flush: Flush) -> BlockState {
 
     state.insert = Ord::min(state.strstart, STD_MIN_MATCH - 1);
 
-    if flush == Flush::Finish {
+    if flush == DeflateFlush::Finish {
         flush_block!(stream, true);
         return BlockState::FinishDone;
     }


### PR DESCRIPTION
because not all variants are valid for both inflate and deflate