### PR TITLE
use `SyncFlush`, test parallel deflate

### DIFF
--- a/load-dynamic-libz-ng/src/lib.rs
+++ b/load-dynamic-libz-ng/src/lib.rs
@@ -165,6 +165,7 @@ pub fn compress_slice<'a>(
     )
 }
 
+#[allow(clippy::too_many_arguments)]
 pub fn compress_slice_with_flush<'a>(
     output: &'a mut [u8],
     input: &[u8],
@@ -191,6 +192,7 @@ pub fn compress_slice_with_flush<'a>(
     )
 }
 
+#[allow(clippy::too_many_arguments)]
 pub fn compress_with_flush<'a>(
     output: &'a mut [MaybeUninit<u8>],
     input: &[u8],

--- a/zlib-rs/src/inflate.rs
+++ b/zlib-rs/src/inflate.rs
@@ -945,7 +945,7 @@ impl<'a> State<'a> {
 
         match self.bit_reader.bits(2) {
             0 => {
-                // eprintln!("inflate:     stored block{last}");
+                // eprintln!("inflate:     stored block (last = {last})");
 
                 self.bit_reader.drop_bits(2);
 
@@ -953,7 +953,7 @@ impl<'a> State<'a> {
                 self.stored()
             }
             1 => {
-                // eprintln!("inflate:     fixed codes block{last}");
+                // eprintln!("inflate:     fixed codes block (last = {last})");
 
                 self.len_table = Table {
                     codes: Codes::Fixed(&self::inffixed_tbl::LENFIX),
@@ -975,7 +975,7 @@ impl<'a> State<'a> {
                 }
             }
             2 => {
-                // eprintln!("inflate:     dynamic codes block{last}");
+                // eprintln!("inflate:     dynamic codes block (last = {last})");
 
                 self.bit_reader.drop_bits(2);
 
@@ -983,8 +983,7 @@ impl<'a> State<'a> {
                 self.table()
             }
             3 => {
-                #[cfg(feature = "std")]
-                eprintln!("inflate:     invalid block type");
+                // eprintln!("inflate:     invalid block type");
 
                 self.bit_reader.drop_bits(2);
 


### PR DESCRIPTION
ultimately, this adds a test that splits the input, deflates the parts, then recombines them into something that can be inflated again. That is how the parallel deflate of `pigz` works. This is very basic right now, but proof that the approach works.