### PR TITLE
use more accurate feature gates

### DIFF
--- a/zlib-rs/src/adler32/neon.rs
+++ b/zlib-rs/src/adler32/neon.rs
@@ -18,7 +18,13 @@ const TAPS: [uint16x8x4_t; 2] = unsafe {
     ])
 };
 
-pub fn adler32_neon(mut adler: u32, buf: &[u8]) -> u32 {
+pub fn adler32_neon(adler: u32, buf: &[u8]) -> u32 {
+    assert!(std::arch::is_aarch64_feature_detected!("neon"));
+    unsafe { adler32_neon_internal(adler, buf) }
+}
+
+#[target_feature(enable = "neon")]
+unsafe fn adler32_neon_internal(mut adler: u32, buf: &[u8]) -> u32 {
     /* split Adler-32 into component sums */
     let sum2 = (adler >> 16) & 0xffff;
     adler &= 0xffff;
@@ -75,6 +81,7 @@ fn handle_tail(mut pair: (u32, u32), buf: &[u8]) -> (u32, u32) {
     pair
 }
 
+#[target_feature(enable = "neon")]
 unsafe fn accum32(s: (u32, u32), buf: &[uint8x16_t]) -> (u32, u32) {
     let mut adacc = vdupq_n_u32(0);
     let mut s2acc = vdupq_n_u32(0);

--- a/zlib-rs/src/deflate/slide_hash.rs
+++ b/zlib-rs/src/deflate/slide_hash.rs
@@ -34,6 +34,12 @@ mod neon {
     };
 
     pub fn slide_hash_chain(table: &mut [u16], wsize: u16) {
+        assert!(std::arch::is_aarch64_feature_detected!("neon"));
+        unsafe { slide_hash_chain_internal(table, wsize) }
+    }
+
+    #[target_feature(enable = "neon")]
+    unsafe fn slide_hash_chain_internal(table: &mut [u16], wsize: u16) {
         debug_assert_eq!(table.len() % 32, 0);
 
         let v = unsafe { vdupq_n_u16(wsize) };
@@ -47,6 +53,7 @@ mod neon {
         }
     }
 
+    #[target_feature(enable = "neon")]
     unsafe fn vqsubq_u16_x4_x1(a: uint16x8x4_t, b: uint16x8_t) -> uint16x8x4_t {
         uint16x8x4_t(
             vqsubq_u16(a.0, b),
@@ -64,6 +71,12 @@ mod avx2 {
     };
 
     pub fn slide_hash_chain(table: &mut [u16], wsize: u16) {
+        assert!(std::is_x86_feature_detected!("avx2"));
+        unsafe { slide_hash_chain_internal(table, wsize) }
+    }
+
+    #[target_feature(enable = "avx2")]
+    unsafe fn slide_hash_chain_internal(table: &mut [u16], wsize: u16) {
         debug_assert_eq!(table.len() % 16, 0);
 
         let ymm_wsize = unsafe { _mm256_set1_epi16(wsize as i16) };


### PR DESCRIPTION
; this makes it possible to inline intrinsics even when the feature flag is not enabled