### PR TITLE
prepare tests for miri

### DIFF
--- a/zlib-rs/src/adler32/avx2.rs
+++ b/zlib-rs/src/adler32/avx2.rs
@@ -226,6 +226,7 @@ mod test {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn large_input() {
         const DEFAULT: &str =
             include_str!("../deflate/test-data/zlib-ng/CVE-2018-25032/default.txt");

--- a/zlib-rs/src/allocate.rs
+++ b/zlib-rs/src/allocate.rs
@@ -265,10 +265,12 @@ impl<'a> Allocator<'a> {
 #[cfg(test)]
 mod tests {
     use core::sync::atomic::{AtomicPtr, Ordering};
+    use std::sync::Mutex;
 
     use super::*;
 
     static PTR: AtomicPtr<c_void> = AtomicPtr::new(core::ptr::null_mut());
+    static MUTEX: Mutex<()> = Mutex::new(());
 
     unsafe extern "C" fn unaligned_alloc(
         _opaque: *mut c_void,
@@ -285,6 +287,9 @@ mod tests {
 
     fn unaligned_allocator_help<T>() {
         let mut buf = [0u8; 1024];
+
+        // we don't want anyone else messing with the PTR static
+        let _guard = MUTEX.lock().unwrap();
 
         for i in 0..64 {
             let ptr = unsafe { buf.as_mut_ptr().add(i).cast() };

--- a/zlib-rs/src/crc32/braid.rs
+++ b/zlib-rs/src/crc32/braid.rs
@@ -154,18 +154,21 @@ mod test {
             crc32_words(&v[..], start) == h.finalize()
         }
 
+        #[cfg_attr(miri, ignore)]
         fn braid_4_is_crc32fast(v: Vec<u8>, start: u32) -> bool {
             let mut h = crc32fast::Hasher::new_with_initial(start);
             h.update(&v[..]);
             crc32_braid::<4>(start, &v[..]) == h.finalize()
         }
 
+        #[cfg_attr(miri, ignore)]
         fn braid_5_is_crc32fast(v: Vec<u8>, start: u32) -> bool {
             let mut h = crc32fast::Hasher::new_with_initial(start);
             h.update(&v[..]);
             crc32_braid::<5>(start, &v[..]) == h.finalize()
         }
 
+        #[cfg_attr(miri, ignore)]
         fn braid_6_is_crc32fast(v: Vec<u8>, start: u32) -> bool {
             let mut h = crc32fast::Hasher::new_with_initial(start);
             h.update(&v[..]);


### PR DESCRIPTION
this requires an unmerged PR on miri right now, but I'm hopeful that'll get merged soon. In any case this fixes some memory issues in tests (the actual library logic is fine!)