### PR TITLE
fix `inflate::uncompress` bug

### DIFF
--- a/zlib-rs/src/inflate.rs
+++ b/zlib-rs/src/inflate.rs
@@ -163,19 +163,13 @@ pub fn uncompress<'a>(
 
     let mut stream = z_stream {
         next_in: input.as_ptr() as *mut u8,
-        avail_in: input.len() as _,
-        total_in: 0,
-        next_out: dest,
-        avail_out: output.len() as _,
-        total_out: 0,
-        msg: core::ptr::null_mut(),
-        state: core::ptr::null_mut(),
+        avail_in: 0,
+
         zalloc: None,
         zfree: None,
         opaque: core::ptr::null_mut(),
-        data_type: 0,
-        adler: 0,
-        reserved: 0,
+
+        ..z_stream::default()
     };
 
     let err = init(&mut stream, config);
@@ -196,7 +190,7 @@ pub fn uncompress<'a>(
             left -= stream.avail_out as u64;
         }
 
-        if stream.avail_out == 0 {
+        if stream.avail_in == 0 {
             stream.avail_in = Ord::min(len, u32::MAX as u64) as u32;
             len -= stream.avail_in as u64;
         }

--- a/zlib-rs/src/inflate.rs
+++ b/zlib-rs/src/inflate.rs
@@ -2266,3 +2266,25 @@ pub fn get_header<'a>(
     });
     ReturnCode::Ok
 }
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn uncompress_buffer_overflow() {
+        let mut output = [0; 1 << 13];
+        let input = [
+            72, 137, 58, 0, 3, 39, 255, 255, 255, 255, 255, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14,
+            14, 14, 184, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 184, 14, 14,
+            14, 14, 14, 14, 14, 63, 14, 14, 14, 14, 14, 14, 14, 14, 184, 14, 14, 255, 14, 103, 14,
+            14, 14, 14, 14, 14, 61, 14, 255, 255, 63, 14, 14, 14, 14, 14, 14, 14, 14, 184, 14, 14,
+            255, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 6, 14, 14, 14, 14, 14, 14, 14, 14, 71,
+            4, 137, 106,
+        ];
+
+        let config = InflateConfig { window_bits: 15 };
+
+        let (_decompressed, err) = uncompress_slice(&mut output, &input, config);
+        assert_eq!(err, ReturnCode::DataError);
+    }
+}


### PR DESCRIPTION
This could access out of bounds memory. The cause is just a silly mixup of `avail_in` and `avail_out`