### PR TITLE
make `libz-rs-sys` and `zlib-rs` use their local README.md for crates.io

### DIFF
--- a/libz-rs-sys/Cargo.toml
+++ b/libz-rs-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libz-rs-sys"
-readme.workspace = true
+readme = "README.md"
 description.workspace = true
 version.workspace = true
 edition.workspace = true

--- a/zlib-rs/Cargo.toml
+++ b/zlib-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zlib-rs"
-readme.workspace = true
+readme = "README.md"
 description.workspace = true
 version.workspace = true
 edition.workspace = true


### PR DESCRIPTION
fix https://github.com/memorysafety/zlib-rs/issues/119