### PR TITLE
Symbol visibility fixes

### DIFF
--- a/libz-rs-sys/README.md
+++ b/libz-rs-sys/README.md
@@ -11,7 +11,7 @@ Add a custom prefix to all exported symbols.
 
 The value of the `LIBZ_RS_SYS_PREFIX` is used as a prefix for all exported symbols. For example:
 
-```
+```ignore
 > LIBZ_RS_SYS_PREFIX="MY_CUSTOM_PREFIX" cargo build -p libz-rs-sys --features=custom-prefix
    Compiling libz-rs-sys v0.2.1 (/home/folkertdev/rust/zlib-rs/libz-rs-sys)
     Finished `dev` profile [optimized + debuginfo] target(s) in 0.21s

--- a/libz-rs-sys/src/lib.rs
+++ b/libz-rs-sys/src/lib.rs
@@ -649,6 +649,14 @@ pub unsafe extern "C" fn deflateTune(
     }
 }
 
+#[export_name = prefix!(zError)]
+pub const unsafe extern "C" fn error_message(err: c_int) -> *const c_char {
+    match ReturnCode::try_from_c_int(err) {
+        Some(return_code) => return_code.error_message(),
+        None => core::ptr::null(),
+    }
+}
+
 // the first part of this version specifies the zlib that we're compatible with (in terms of
 // supported functions). In practice in most cases only the major version is checked, unless
 // specific functions that were added later are used.

--- a/libz-rs-sys/src/lib.rs
+++ b/libz-rs-sys/src/lib.rs
@@ -667,6 +667,7 @@ unsafe fn is_version_compatible(version: *const c_char, stream_size: i32) -> boo
     core::mem::size_of::<z_stream>() as i32 == stream_size
 }
 
+#[export_name = prefix!(zlibVersion)]
 pub const extern "C" fn zlibVersion() -> *const c_char {
     LIBZ_RS_SYS_VERSION.as_ptr() as *const c_char
 }

--- a/libz-rs-sys/src/lib.rs
+++ b/libz-rs-sys/src/lib.rs
@@ -272,8 +272,7 @@ pub unsafe extern "C" fn inflateInit2_(
     }
 }
 
-#[export_name = prefix!(inflateInit2)]
-pub unsafe extern "C" fn inflateInit2(strm: z_streamp, windowBits: c_int) -> c_int {
+unsafe extern "C" fn inflateInit2(strm: z_streamp, windowBits: c_int) -> c_int {
     if strm.is_null() {
         ReturnCode::StreamError as _
     } else {


### PR DESCRIPTION
found some differences vs stock zlib using this script https://github.com/memorysafety/zlib-rs/issues/34#issuecomment-2266685818

So now the only missing symbols are the gz symbols, versioning and `get_crc_table`, which I believe is just part of a `DYNAMIC_CRC_TABLE` feature that we don't currently support