### PR TITLE
gate the `crc32_hash_calc` test on x86, x86_64 and aarch64

### DIFF
--- a/zlib-rs/src/deflate/hash_calc.rs
+++ b/zlib-rs/src/deflate/hash_calc.rs
@@ -163,6 +163,10 @@ mod tests {
     use super::*;
 
     #[test]
+    #[cfg_attr(
+        not(any(target_arch = "x86", target_arch = "x86_64", target_arch = "aarch64")),
+        ignore = "no crc32 hardware support on this platform"
+    )]
     fn crc32_hash_calc() {
         assert_eq!(Crc32HashCalc::hash_calc(0, 807411760), 2423125009);
         assert_eq!(Crc32HashCalc::hash_calc(0, 540024864), 1452438466);


### PR DESCRIPTION
fixes #135

This test is for the crc32 intrinsics that x86(_64) and aarch64 provide. The test is now ignored on other archtectures, in particular powerpc, which fedora builds for.