### PR TITLE
fix test suite on `s390x-unknown-linux-gnu`

### DIFF
--- a/zlib-rs/src/crc32/acle.rs
+++ b/zlib-rs/src/crc32/acle.rs
@@ -42,12 +42,12 @@ pub fn crc32_acle_arm(crc: u32, buf: &[u8]) -> u32 {
 
 fn remainder(mut c: u32, mut buf: &[u8]) -> u32 {
     if let [b0, b1, b2, b3, rest @ ..] = buf {
-        c = unsafe { __crc32w(c, u32::from_ne_bytes([*b0, *b1, *b2, *b3])) };
+        c = unsafe { __crc32w(c, u32::from_le_bytes([*b0, *b1, *b2, *b3])) };
         buf = rest;
     }
 
     if let [b0, b1, rest @ ..] = buf {
-        c = unsafe { __crc32h(c, u16::from_ne_bytes([*b0, *b1])) };
+        c = unsafe { __crc32h(c, u16::from_le_bytes([*b0, *b1])) };
         buf = rest;
     }
 

--- a/zlib-rs/src/deflate/compare256.rs
+++ b/zlib-rs/src/deflate/compare256.rs
@@ -62,7 +62,7 @@ mod rust {
         // this optimizes well because we statically limit the slice to 256 bytes.
         // the loop gets unrolled 4 times automatically.
         for chunk in src[..256].chunks_exact(8) {
-            let mv = u64::from_ne_bytes(chunk.try_into().unwrap());
+            let mv = u64::from_le_bytes(chunk.try_into().unwrap());
 
             let diff = sv ^ mv;
 

--- a/zlib-rs/src/deflate/hash_calc.rs
+++ b/zlib-rs/src/deflate/hash_calc.rs
@@ -152,7 +152,7 @@ impl HashCalc for Crc32HashCalc {
     }
 
     #[cfg(not(any(target_arch = "x86", target_arch = "x86_64", target_arch = "aarch64")))]
-    fn hash_calc(h: u32, val: u32) -> u32 {
+    fn hash_calc(_h: u32, _val: u32) -> u32 {
         assert!(!Self::is_supported());
         unimplemented!("there is no hardware support on this platform")
     }

--- a/zlib-rs/src/deflate/hash_calc.rs
+++ b/zlib-rs/src/deflate/hash_calc.rs
@@ -19,7 +19,7 @@ pub trait HashCalc {
 
     fn quick_insert_string(state: &mut State, string: usize) -> u16 {
         let slice = &state.window.filled()[string + Self::HASH_CALC_OFFSET..];
-        let val = u32::from_ne_bytes(slice[..4].try_into().unwrap());
+        let val = u32::from_le_bytes(slice[..4].try_into().unwrap());
 
         let hm = (Self::hash_calc(0, val) & Self::HASH_CALC_MASK) as usize;
 
@@ -39,7 +39,7 @@ pub trait HashCalc {
         for (i, w) in slice[..count + 3].windows(4).enumerate() {
             let idx = string as u16 + i as u16;
 
-            let val = u32::from_ne_bytes(w.try_into().unwrap());
+            let val = u32::from_le_bytes(w.try_into().unwrap());
 
             let hm = (Self::hash_calc(0, val) & Self::HASH_CALC_MASK) as usize;
 

--- a/zlib-rs/src/inflate.rs
+++ b/zlib-rs/src/inflate.rs
@@ -624,7 +624,7 @@ impl<'a> State<'a> {
         }
 
         if (self.flags & 0x0200) != 0 && (self.wrap & 4) != 0 {
-            let bytes = (self.bit_reader.hold() as u32).to_ne_bytes();
+            let bytes = (self.bit_reader.hold() as u32).to_le_bytes();
             self.checksum = crc32(self.checksum, &bytes);
         }
 
@@ -641,7 +641,7 @@ impl<'a> State<'a> {
         }
 
         if (self.flags & 0x0200) != 0 && (self.wrap & 4) != 0 {
-            let bytes = (self.bit_reader.hold() as u16).to_ne_bytes();
+            let bytes = (self.bit_reader.hold() as u16).to_le_bytes();
             self.checksum = crc32(self.checksum, &bytes);
         }
 
@@ -661,7 +661,7 @@ impl<'a> State<'a> {
             }
 
             if (self.flags & 0x0200) != 0 && (self.wrap & 4) != 0 {
-                let bytes = (self.bit_reader.hold() as u16).to_ne_bytes();
+                let bytes = (self.bit_reader.hold() as u16).to_le_bytes();
                 self.checksum = crc32(self.checksum, &bytes);
             }
             self.bit_reader.init_bits();

--- a/zlib-rs/src/inflate/bitreader.rs
+++ b/zlib-rs/src/inflate/bitreader.rs
@@ -103,7 +103,7 @@ impl<'a> BitReader<'a> {
     pub fn refill(&mut self) {
         debug_assert!(self.bytes_remaining() >= 8);
 
-        let read = unsafe { core::ptr::read_unaligned(self.ptr.cast::<u64>()) };
+        let read = unsafe { core::ptr::read_unaligned(self.ptr.cast::<u64>()) }.to_le();
         self.bit_buffer |= read << self.bits_used;
         let increment = (63 - self.bits_used) >> 3;
         self.ptr = self.ptr.wrapping_add(increment as usize);
@@ -116,7 +116,7 @@ impl<'a> BitReader<'a> {
 
         // the trick of this function is that the read can happen concurrently
         // with the arithmetic below. That makes the read effectively free.
-        let read = unsafe { core::ptr::read_unaligned(self.ptr.cast::<u64>()) };
+        let read = unsafe { core::ptr::read_unaligned(self.ptr.cast::<u64>()) }.to_le();
         let next_bit_buffer = self.bit_buffer | read << self.bits_used;
 
         let increment = (63 - self.bits_used) >> 3;

--- a/zlib-rs/src/read_buf.rs
+++ b/zlib-rs/src/read_buf.rs
@@ -498,7 +498,7 @@ impl Chunk for u64 {
 
     unsafe fn store_chunk(out: *mut MaybeUninit<u8>, chunk: Self) {
         core::ptr::copy_nonoverlapping(
-            chunk.to_ne_bytes().as_ptr().cast(),
+            chunk.to_le_bytes().as_ptr().cast(),
             out,
             core::mem::size_of::<Self>(),
         )

--- a/zlib-rs/src/read_buf.rs
+++ b/zlib-rs/src/read_buf.rs
@@ -493,7 +493,7 @@ trait Chunk {
 
 impl Chunk for u64 {
     unsafe fn load_chunk(from: *const MaybeUninit<u8>) -> Self {
-        core::ptr::read_unaligned(from.cast())
+        u64::to_le(core::ptr::read_unaligned(from.cast()))
     }
 
     unsafe fn store_chunk(out: *mut MaybeUninit<u8>, chunk: Self) {


### PR DESCRIPTION
fixes #136 

These changes make our test suite pass for me with the `s390x-unknown-linux-gnu` target, which is big-endian. The changes are the usual suspects where endiannes was ignored.

for future me: I ran this with

```toml
[target.s390x-unknown-linux-gnu]
runner = "qemu-s390x -L /usr/s390x-linux-gnu"
linker = "s390x-linux-gnu-gcc"
```

I had to install that gcc compiler/linker; zig did sadly not work here.