### PR TITLE
switch the instruction used for acle crc32 calculation

### DIFF
--- a/zlib-rs/src/crc32/acle.rs
+++ b/zlib-rs/src/crc32/acle.rs
@@ -86,7 +86,7 @@ unsafe fn __crc32h(mut crc: u32, data: u16) -> u32 {
 /// [Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/__crc32w)
 #[target_feature(enable = "crc")]
 #[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
-unsafe fn __crc32w(mut crc: u32, data: u32) -> u32 {
+pub unsafe fn __crc32w(mut crc: u32, data: u32) -> u32 {
     core::arch::asm!("crc32w {crc:w}, {crc:w}, {data:w}", crc = inout(reg) crc, data = in(reg) data);
     crc
 }

--- a/zlib-rs/src/deflate.rs
+++ b/zlib-rs/src/deflate.rs
@@ -4066,7 +4066,13 @@ mod test {
         // the output is slightly different based on what hashing algorithm is used
         match HashCalcVariant::for_compression_level(config.level as usize) {
             HashCalcVariant::Crc32 => {
-                fuzz_based_test(&input, config, &crc32);
+                // the aarch64 hashing algorithm is different from the standard algorithm, but in
+                // this case they turn out to give the same output. Beware!
+                if cfg!(target_arch = "x86") || cfg!(target_arch = "x86_64") {
+                    fuzz_based_test(&input, config, &crc32);
+                } else {
+                    fuzz_based_test(&input, config, &other);
+                }
             }
             HashCalcVariant::Standard | HashCalcVariant::Roll => {
                 fuzz_based_test(&input, config, &other);


### PR DESCRIPTION
this is to match the current version of zlib-ng that we're trying to be compatible with