### PR TITLE
refinements to unsafe code

### DIFF
--- a/libz-rs-sys/src/lib.rs
+++ b/libz-rs-sys/src/lib.rs
@@ -1,20 +1,29 @@
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]
-#![doc = include_str!("../README.md")]
 #![cfg_attr(not(feature = "std"), no_std)]
+#![doc = include_str!("../README.md")]
 
-//! # Safety of `*mut z_stream`
+//! # Safety
 //!
-//! Most functions require an argument of type `*mut z_stream`. Unless
-//! otherwise noted, the safety requirements on such arguments are at least that the
-//! pointer must be either:
+//! Most of the functions in this module are `unsafe fn`s, meaning that their behavior may be
+//! undefined if certain assumptions are broken by the caller. In most cases, documentation
+//! in this module refers to the safety assumptions of standard library functions.
 //!
-//! - A `NULL` pointer
-//! - A pointer to a correctly aligned, initialized value of type `z_stream`.
+//! In most cases, pointers must be either `NULL` or satisfy the requirements of `&*ptr` or `&mut
+//! *ptr`. This requirement maps to the requirements of [`pointer::as_ref`] and [`pointer::as_mut`]
+//! for immutable and mutable pointers respectively.
 //!
-//! In other words, it must be safe to cast the `*mut z_stream` to a `Option<&mut z_stream>`. It is
-//! always safe to provide an argument of type `&mut z_stream`: rust will automatically downcast
-//! the argument to `*mut z_stream`.
+//! For pointer and length pairs, describing some sequence of elements in memory, the requirements
+//! of [`core::slice::from_raw_parts`] or [`core::slice::from_raw_parts_mut`] apply. In some cases,
+//! the element type `T` is converted into `MaybeUninit<T>`, meaning that while the slice must be
+//! valid, the elements in the slice can be uninitialized. Using uninitialized buffers for output
+//! is more performant.
+//!
+//! Finally, some functions accept a string argument, which must either be `NULL` or satisfy the
+//! requirements of [`core::ffi::CStr::from_ptr`].
+//!
+//! [`pointer::as_ref`]: https://doc.rust-lang.org/core/primitive.pointer.html#method.as_ref
+//! [`pointer::as_mut`]: https://doc.rust-lang.org/core/primitive.pointer.html#method.as_mut
 
 use core::mem::MaybeUninit;
 

--- a/libz-rs-sys/src/lib.rs
+++ b/libz-rs-sys/src/lib.rs
@@ -620,9 +620,6 @@ pub unsafe extern "C" fn inflateInit2_(
 /// * Either
 ///     - `strm` is `NULL`
 ///     - `strm` satisfies the requirements of `&mut *strm`
-/// * Either
-///     - `version` is NULL
-///     - `version` satisfies the requirements of [`core::ffi::CStr::from_ptr`]
 /// * If `strm` is not `NULL`, the following fields contain valid values
 ///     - `zalloc`
 ///     - `zfree`

--- a/libz-rs-sys/src/lib.rs
+++ b/libz-rs-sys/src/lib.rs
@@ -754,10 +754,7 @@ pub unsafe extern "C" fn inflateSetDictionary(
 
     let dict = match dictLength {
         0 => &[],
-        _ => match unsafe { slice_from_raw_parts(dictionary, dictLength as usize) } {
-            None => &[],
-            Some(slice) => slice,
-        },
+        _ => unsafe { slice_from_raw_parts(dictionary, dictLength as usize) }.unwrap_or(&[]),
     };
 
     zlib_rs::inflate::set_dictionary(stream, dict) as _

--- a/libz-rs-sys/src/lib.rs
+++ b/libz-rs-sys/src/lib.rs
@@ -391,7 +391,7 @@ pub unsafe extern "C" fn inflateEnd(strm: *mut z_stream) -> i32 {
 ///
 /// * Either
 ///     - `strm` is `NULL`
-///     - `strm` satisfies the requirements of [`pointer::as_mut`]
+///     - `strm` satisfies the requirements of `&mut *strm`
 /// * Either
 ///     - `version` is NULL
 ///     - `version` satisfies the requirements of [`core::ffi::CStr::from_ptr`]
@@ -399,8 +399,6 @@ pub unsafe extern "C" fn inflateEnd(strm: *mut z_stream) -> i32 {
 ///     - `zalloc`
 ///     - `zfree`
 ///     - `opaque`
-///
-/// [`pointer::as_mut`]: https://doc.rust-lang.org/core/primitive.pointer.html#method.as_mut
 #[export_name = prefix!(inflateBackInit_)]
 pub unsafe extern "C" fn inflateBackInit_(
     _strm: z_streamp,
@@ -589,7 +587,7 @@ pub unsafe extern "C" fn inflateSyncPoint(strm: *mut z_stream) -> i32 {
 ///
 /// * Either
 ///     - `strm` is `NULL`
-///     - `strm` satisfies the requirements of [`pointer::as_mut`]
+///     - `strm` satisfies the requirements of `&mut *strm`
 /// * Either
 ///     - `version` is NULL
 ///     - `version` satisfies the requirements of [`core::ffi::CStr::from_ptr`]
@@ -597,8 +595,6 @@ pub unsafe extern "C" fn inflateSyncPoint(strm: *mut z_stream) -> i32 {
 ///     - `zalloc`
 ///     - `zfree`
 ///     - `opaque`
-///
-/// [`pointer::as_mut`]: https://doc.rust-lang.org/core/primitive.pointer.html#method.as_mut
 #[export_name = prefix!(inflateInit_)]
 pub unsafe extern "C" fn inflateInit_(
     strm: z_streamp,
@@ -624,7 +620,7 @@ pub unsafe extern "C" fn inflateInit_(
 ///
 /// * Either
 ///     - `strm` is `NULL`
-///     - `strm` satisfies the requirements of [`pointer::as_mut`]
+///     - `strm` satisfies the requirements of `&mut *strm`
 /// * Either
 ///     - `version` is NULL
 ///     - `version` satisfies the requirements of [`core::ffi::CStr::from_ptr`]
@@ -632,8 +628,6 @@ pub unsafe extern "C" fn inflateInit_(
 ///     - `zalloc`
 ///     - `zfree`
 ///     - `opaque`
-///
-/// [`pointer::as_mut`]: https://doc.rust-lang.org/core/primitive.pointer.html#method.as_mut
 #[export_name = prefix!(inflateInit2_)]
 pub unsafe extern "C" fn inflateInit2_(
     strm: z_streamp,
@@ -656,7 +650,7 @@ pub unsafe extern "C" fn inflateInit2_(
 ///
 /// * Either
 ///     - `strm` is `NULL`
-///     - `strm` satisfies the requirements of [`pointer::as_mut`]
+///     - `strm` satisfies the requirements of `&mut *strm`
 /// * Either
 ///     - `version` is NULL
 ///     - `version` satisfies the requirements of [`core::ffi::CStr::from_ptr`]
@@ -664,8 +658,6 @@ pub unsafe extern "C" fn inflateInit2_(
 ///     - `zalloc`
 ///     - `zfree`
 ///     - `opaque`
-///
-/// [`pointer::as_mut`]: https://doc.rust-lang.org/core/primitive.pointer.html#method.as_mut
 unsafe extern "C" fn inflateInit2(strm: z_streamp, windowBits: c_int) -> c_int {
     if strm.is_null() {
         ReturnCode::StreamError as _
@@ -878,10 +870,6 @@ pub unsafe extern "C" fn inflateSetDictionary(
 ///     - if `head.extra` is not NULL, it must be writable for at least `head.extra_max` bytes
 ///     - if `head.name` is not NULL, it must be writable for at least `head.name_max` bytes
 ///     - if `head.comment` is not NULL, it must be writable for at least `head.comm_max` bytes
-///
-///     It is advised to fully initialize this structure with zeros before setting any fiels,
-///     for instance using [`gz_header::default`] or [`core::mem::MaybeUninit::zeroed`]. Using
-///     a partially uninitialized header struct is extremely dangerous.
 #[export_name = prefix!(inflateGetHeader)]
 pub unsafe extern "C" fn inflateGetHeader(strm: z_streamp, head: gz_headerp) -> c_int {
     let Some(stream) = (unsafe { InflateStream::from_stream_mut(strm) }) else {
@@ -1441,7 +1429,7 @@ pub unsafe extern "C" fn deflateCopy(dest: z_streamp, source: z_streamp) -> c_in
 ///
 /// * Either
 ///     - `strm` is `NULL`
-///     - `strm` satisfies the requirements of [`pointer::as_mut`]
+///     - `strm` satisfies the requirements of `&mut *strm`
 /// * Either
 ///     - `version` is NULL
 ///     - `version` satisfies the requirements of [`core::ffi::CStr::from_ptr`]
@@ -1449,8 +1437,6 @@ pub unsafe extern "C" fn deflateCopy(dest: z_streamp, source: z_streamp) -> c_in
 ///     - `zalloc`
 ///     - `zfree`
 ///     - `opaque`
-///
-/// [`pointer::as_mut`]: https://doc.rust-lang.org/core/primitive.pointer.html#method.as_mut
 ///
 /// # Example
 ///
@@ -1529,7 +1515,7 @@ pub unsafe extern "C" fn deflateInit_(
 ///
 /// * Either
 ///     - `strm` is `NULL`
-///     - `strm` satisfies the requirements of [`pointer::as_mut`]
+///     - `strm` satisfies the requirements of `&mut *strm`
 /// * Either
 ///     - `version` is NULL
 ///     - `version` satisfies the requirements of [`core::ffi::CStr::from_ptr`]
@@ -1537,8 +1523,6 @@ pub unsafe extern "C" fn deflateInit_(
 ///     - `zalloc`
 ///     - `zfree`
 ///     - `opaque`
-///
-/// [`pointer::as_mut`]: https://doc.rust-lang.org/core/primitive.pointer.html#method.as_mut
 ///
 /// # Example
 ///

--- a/libz-rs-sys/src/lib.rs
+++ b/libz-rs-sys/src/lib.rs
@@ -389,14 +389,16 @@ pub unsafe extern "C" fn inflateEnd(strm: *mut z_stream) -> i32 {
 ///
 /// * Either
 ///     - `strm` is `NULL`
-///     - `strm` satisfies the requirements of `&mut *(strm as *mut MaybeUninit<z_stream>)`
+///     - `strm` satisfies the requirements of [`pointer::as_mut`]
 /// * Either
 ///     - `version` is NULL
-///     - `version` satisfies the requirements of [`core::ptr::read::<u8>`]
+///     - `version` satisfies the requirements of [`core::ffi::CStr::from_ptr`]
 /// * If `strm` is not `NULL`, the following fields contain valid values
 ///     - `zalloc`
 ///     - `zfree`
 ///     - `opaque`
+///
+/// [`pointer::as_mut`]: https://doc.rust-lang.org/core/primitive.pointer.html#method.as_mut
 #[export_name = prefix!(inflateBackInit_)]
 pub unsafe extern "C" fn inflateBackInit_(
     _strm: z_streamp,
@@ -585,14 +587,16 @@ pub unsafe extern "C" fn inflateSyncPoint(strm: *mut z_stream) -> i32 {
 ///
 /// * Either
 ///     - `strm` is `NULL`
-///     - `strm` satisfies the requirements of `&mut *(strm as *mut MaybeUninit<z_stream>)`
+///     - `strm` satisfies the requirements of [`pointer::as_mut`]
 /// * Either
 ///     - `version` is NULL
-///     - `version` satisfies the requirements of [`core::ptr::read::<u8>`]
+///     - `version` satisfies the requirements of [`core::ffi::CStr::from_ptr`]
 /// * If `strm` is not `NULL`, the following fields contain valid values
 ///     - `zalloc`
 ///     - `zfree`
 ///     - `opaque`
+///
+/// [`pointer::as_mut`]: https://doc.rust-lang.org/core/primitive.pointer.html#method.as_mut
 #[export_name = prefix!(inflateInit_)]
 pub unsafe extern "C" fn inflateInit_(
     strm: z_streamp,
@@ -618,14 +622,16 @@ pub unsafe extern "C" fn inflateInit_(
 ///
 /// * Either
 ///     - `strm` is `NULL`
-///     - `strm` satisfies the requirements of `&mut *(strm as *mut MaybeUninit<z_stream>)`
+///     - `strm` satisfies the requirements of [`pointer::as_mut`]
 /// * Either
 ///     - `version` is NULL
-///     - `version` satisfies the requirements of [`core::ptr::read::<u8>`]
+///     - `version` satisfies the requirements of [`core::ffi::CStr::from_ptr`]
 /// * If `strm` is not `NULL`, the following fields contain valid values
 ///     - `zalloc`
 ///     - `zfree`
 ///     - `opaque`
+///
+/// [`pointer::as_mut`]: https://doc.rust-lang.org/core/primitive.pointer.html#method.as_mut
 #[export_name = prefix!(inflateInit2_)]
 pub unsafe extern "C" fn inflateInit2_(
     strm: z_streamp,
@@ -648,14 +654,16 @@ pub unsafe extern "C" fn inflateInit2_(
 ///
 /// * Either
 ///     - `strm` is `NULL`
-///     - `strm` satisfies the requirements of `&mut *(strm as *mut MaybeUninit<z_stream>)`
+///     - `strm` satisfies the requirements of [`pointer::as_mut`]
 /// * Either
 ///     - `version` is NULL
-///     - `version` satisfies the requirements of [`core::ptr::read::<u8>`]
+///     - `version` satisfies the requirements of [`core::ffi::CStr::from_ptr`]
 /// * If `strm` is not `NULL`, the following fields contain valid values
 ///     - `zalloc`
 ///     - `zfree`
 ///     - `opaque`
+///
+/// [`pointer::as_mut`]: https://doc.rust-lang.org/core/primitive.pointer.html#method.as_mut
 unsafe extern "C" fn inflateInit2(strm: z_streamp, windowBits: c_int) -> c_int {
     if strm.is_null() {
         ReturnCode::StreamError as _
@@ -1457,14 +1465,16 @@ pub unsafe extern "C" fn deflateCopy(dest: z_streamp, source: z_streamp) -> c_in
 ///
 /// * Either
 ///     - `strm` is `NULL`
-///     - `strm` satisfies the requirements of `&mut *(strm as *mut MaybeUninit<z_stream>)`
+///     - `strm` satisfies the requirements of [`pointer::as_mut`]
 /// * Either
 ///     - `version` is NULL
-///     - `version` satisfies the requirements of [`core::ptr::read::<u8>`]
+///     - `version` satisfies the requirements of [`core::ffi::CStr::from_ptr`]
 /// * If `strm` is not `NULL`, the following fields contain valid values
 ///     - `zalloc`
 ///     - `zfree`
 ///     - `opaque`
+///
+/// [`pointer::as_mut`]: https://doc.rust-lang.org/core/primitive.pointer.html#method.as_mut
 ///
 /// # Example
 ///
@@ -1543,14 +1553,16 @@ pub unsafe extern "C" fn deflateInit_(
 ///
 /// * Either
 ///     - `strm` is `NULL`
-///     - `strm` satisfies the requirements of `&mut *(strm as *mut MaybeUninit<z_stream>)`
+///     - `strm` satisfies the requirements of [`pointer::as_mut`]
 /// * Either
 ///     - `version` is NULL
-///     - `version` satisfies the requirements of [`core::ptr::read::<u8>`]
+///     - `version` satisfies the requirements of [`core::ffi::CStr::from_ptr`]
 /// * If `strm` is not `NULL`, the following fields contain valid values
 ///     - `zalloc`
 ///     - `zfree`
 ///     - `opaque`
+///
+/// [`pointer::as_mut`]: https://doc.rust-lang.org/core/primitive.pointer.html#method.as_mut
 ///
 /// # Example
 ///

--- a/libz-rs-sys/src/lib.rs
+++ b/libz-rs-sys/src/lib.rs
@@ -393,7 +393,7 @@ pub unsafe extern "C" fn inflateEnd(strm: *mut z_stream) -> i32 {
 /// * Either
 ///     - `version` is NULL
 ///     - `version` satisfies the requirements of [`core::ptr::read::<u8>`]
-/// * If `strm` is not `NULL`, the following fields must be initialized
+/// * If `strm` is not `NULL`, the following fields contain valid values
 ///     - `zalloc`
 ///     - `zfree`
 ///     - `opaque`
@@ -589,9 +589,7 @@ pub unsafe extern "C" fn inflateSyncPoint(strm: *mut z_stream) -> i32 {
 /// * Either
 ///     - `version` is NULL
 ///     - `version` satisfies the requirements of [`core::ptr::read::<u8>`]
-/// * If `strm` is not `NULL`, the following fields must be initialized
-///     - `next_in`
-///     - `avail_in`
+/// * If `strm` is not `NULL`, the following fields contain valid values
 ///     - `zalloc`
 ///     - `zfree`
 ///     - `opaque`
@@ -624,9 +622,7 @@ pub unsafe extern "C" fn inflateInit_(
 /// * Either
 ///     - `version` is NULL
 ///     - `version` satisfies the requirements of [`core::ptr::read::<u8>`]
-/// * If `strm` is not `NULL`, the following fields must be initialized
-///     - `next_in`
-///     - `avail_in`
+/// * If `strm` is not `NULL`, the following fields contain valid values
 ///     - `zalloc`
 ///     - `zfree`
 ///     - `opaque`
@@ -656,9 +652,7 @@ pub unsafe extern "C" fn inflateInit2_(
 /// * Either
 ///     - `version` is NULL
 ///     - `version` satisfies the requirements of [`core::ptr::read::<u8>`]
-/// * If `strm` is not `NULL`, the following fields must be initialized
-///     - `next_in`
-///     - `avail_in`
+/// * If `strm` is not `NULL`, the following fields contain valid values
 ///     - `zalloc`
 ///     - `zfree`
 ///     - `opaque`
@@ -1467,7 +1461,7 @@ pub unsafe extern "C" fn deflateCopy(dest: z_streamp, source: z_streamp) -> c_in
 /// * Either
 ///     - `version` is NULL
 ///     - `version` satisfies the requirements of [`core::ptr::read::<u8>`]
-/// * If `strm` is not `NULL`, the following fields must be initialized
+/// * If `strm` is not `NULL`, the following fields contain valid values
 ///     - `zalloc`
 ///     - `zfree`
 ///     - `opaque`
@@ -1553,7 +1547,7 @@ pub unsafe extern "C" fn deflateInit_(
 /// * Either
 ///     - `version` is NULL
 ///     - `version` satisfies the requirements of [`core::ptr::read::<u8>`]
-/// * If `strm` is not `NULL`, the following fields must be initialized
+/// * If `strm` is not `NULL`, the following fields contain valid values
 ///     - `zalloc`
 ///     - `zfree`
 ///     - `opaque`

--- a/libz-rs-sys/src/lib.rs
+++ b/libz-rs-sys/src/lib.rs
@@ -20,7 +20,6 @@ use core::mem::MaybeUninit;
 
 use core::ffi::{c_char, c_int, c_long, c_uchar, c_uint, c_ulong, c_void};
 
-use zlib_rs::allocate::Allocator;
 use zlib_rs::{
     deflate::{DeflateConfig, DeflateStream, Method, Strategy},
     inflate::{InflateConfig, InflateStream},
@@ -56,32 +55,6 @@ macro_rules! prefix {
 #[cfg(all(feature = "rust-allocator", feature = "c-allocator"))]
 const _: () =
     compile_error!("Only one of `rust-allocator` and `c-allocator` can be enabled at a time");
-
-#[allow(unreachable_code)]
-const DEFAULT_ALLOCATOR: Option<Allocator<'static>> = '_blk: {
-    // this `break 'blk'` construction exists to generate just one compile error and not other
-    // warnings when multiple allocators are configured.
-
-    #[cfg(feature = "c-allocator")]
-    break '_blk Some(zlib_rs::allocate::Allocator::C);
-
-    #[cfg(feature = "rust-allocator")]
-    break '_blk Some(zlib_rs::allocate::Allocator::RUST);
-
-    None
-};
-
-#[allow(unreachable_code)]
-const DEFAULT_ZALLOC: Option<alloc_func> = match DEFAULT_ALLOCATOR {
-    Some(allocator) => Some(allocator.zalloc),
-    None => None,
-};
-
-#[allow(unreachable_code)]
-const DEFAULT_ZFREE: Option<free_func> = match DEFAULT_ALLOCATOR {
-    Some(allocator) => Some(allocator.zfree),
-    None => None,
-};
 
 // In spirit this type is `libc::off_t`, but it would be our only libc dependency, and so we
 // hardcode the type here. This should be correct on most operating systems. If we ever run into

--- a/libz-rs-sys/src/lib.rs
+++ b/libz-rs-sys/src/lib.rs
@@ -217,7 +217,9 @@ pub extern "C" fn adler32_combine(adler1: c_ulong, adler2: c_ulong, len2: z_off_
 ///
 /// The caller must guarantee that
 ///
-/// * The `destLen` pointer satisfies the requirements of [`core::ptr::read`]
+/// * Either
+///     - `destLen` is `NULL`
+///     - `destLen` satisfies the requirements of `&mut *destLen`
 /// * Either
 ///     - `dest` is `NULL`
 ///     - `dest` and `*destLen` satisfy the requirements of [`core::slice::from_raw_parts_mut::<MaybeUninit<u8>>`]
@@ -1026,7 +1028,9 @@ pub unsafe extern "C" fn compress(
 ///
 /// The caller must guarantee that
 ///
-/// * The `destLen` pointer satisfies the requirements of `&mut *destLen`
+/// * Either
+///     - `destLen` is `NULL`
+///     - `destLen` satisfies the requirements of `&mut *destLen`
 /// * Either
 ///     - `dest` is `NULL`
 ///     - `dest` and `*destLen` satisfy the requirements of [`core::slice::from_raw_parts_mut::<MaybeUninit<u8>>`]

--- a/test-libz-rs-sys/src/lib.rs
+++ b/test-libz-rs-sys/src/lib.rs
@@ -327,7 +327,7 @@ mod null {
     }
 
     #[test]
-    fn inflate_get_header_uninitialized() {
+    fn inflate_get_header_zeroed() {
         const FERRIS_BYTES_GZ_NO_HEADER: [u8; 26] = [
             31, 139, 8, 0, 0, 0, 0, 0, 0, 3, 115, 75, 45, 42, 202, 44, 6, 0, 174, 148, 97, 210, 6,
             0, 0, 0,
@@ -409,7 +409,7 @@ mod null {
             let mut strm = MaybeUninit::<z_stream>::zeroed();
 
             fn initialize_header_null() -> MaybeUninit<gz_header> {
-                let mut head = MaybeUninit::<gz_header>::uninit();
+                let mut head = MaybeUninit::<gz_header>::zeroed();
 
                 unsafe {
                     core::ptr::write(
@@ -434,7 +434,7 @@ mod null {
                 name: &mut [u8],
                 comment: &mut [u8],
             ) -> MaybeUninit<gz_header> {
-                let mut head = MaybeUninit::<gz_header>::uninit();
+                let mut head = MaybeUninit::<gz_header>::zeroed();
 
                 unsafe {
                     core::ptr::write(


### PR DESCRIPTION
among other things

- the `Init` and `GetHeader` functions now assume that their arguments are properly initialized in the rust sense. Providing uninitialized memory to these functions is UB, though unlikely to actually cause issues across an FFI boundary
- 