### PR TITLE
correct target features in `hash_calc`

### DIFF
--- a/zlib-rs/src/deflate.rs
+++ b/zlib-rs/src/deflate.rs
@@ -12,7 +12,7 @@ use crate::{
 
 use self::{
     algorithm::CONFIGURATION_TABLE,
-    hash_calc::{Crc32HashCalc, HashCalc, HashCalcVariant, RollHashCalc, StandardHashCalc},
+    hash_calc::{Crc32HashCalc, HashCalcVariant, RollHashCalc, StandardHashCalc},
     pending::Pending,
     trees_tbl::STATIC_LTREE,
     window::Window,
@@ -1338,7 +1338,7 @@ impl<'a> State<'a> {
     pub(crate) fn update_hash(&self, h: u32, val: u32) -> u32 {
         match self.hash_calc_variant {
             HashCalcVariant::Standard => StandardHashCalc::update_hash(h, val),
-            HashCalcVariant::Crc32 => Crc32HashCalc::update_hash(h, val),
+            HashCalcVariant::Crc32 => unsafe { Crc32HashCalc::update_hash(h, val) },
             HashCalcVariant::Roll => RollHashCalc::update_hash(h, val),
         }
     }
@@ -1346,7 +1346,7 @@ impl<'a> State<'a> {
     pub(crate) fn quick_insert_string(&mut self, string: usize) -> u16 {
         match self.hash_calc_variant {
             HashCalcVariant::Standard => StandardHashCalc::quick_insert_string(self, string),
-            HashCalcVariant::Crc32 => Crc32HashCalc::quick_insert_string(self, string),
+            HashCalcVariant::Crc32 => unsafe { Crc32HashCalc::quick_insert_string(self, string) },
             HashCalcVariant::Roll => RollHashCalc::quick_insert_string(self, string),
         }
     }
@@ -1354,7 +1354,7 @@ impl<'a> State<'a> {
     pub(crate) fn insert_string(&mut self, string: usize, count: usize) {
         match self.hash_calc_variant {
             HashCalcVariant::Standard => StandardHashCalc::insert_string(self, string, count),
-            HashCalcVariant::Crc32 => Crc32HashCalc::insert_string(self, string, count),
+            HashCalcVariant::Crc32 => unsafe { Crc32HashCalc::insert_string(self, string, count) },
             HashCalcVariant::Roll => RollHashCalc::insert_string(self, string, count),
         }
     }

--- a/zlib-rs/src/deflate/hash_calc.rs
+++ b/zlib-rs/src/deflate/hash_calc.rs
@@ -1,3 +1,4 @@
+#![warn(unsafe_op_in_unsafe_fn)]
 use crate::deflate::{State, HASH_SIZE, STD_MIN_MATCH};
 
 #[derive(Debug, Clone, Copy)]
@@ -27,21 +28,27 @@ impl HashCalcVariant {
     }
 }
 
-pub trait HashCalc {
-    const HASH_CALC_OFFSET: usize;
-    const HASH_CALC_MASK: u32;
+pub struct StandardHashCalc;
 
-    fn hash_calc(h: u32, val: u32) -> u32;
+impl StandardHashCalc {
+    const HASH_CALC_OFFSET: usize = 0;
 
-    fn update_hash(h: u32, val: u32) -> u32 {
+    const HASH_CALC_MASK: u32 = (HASH_SIZE - 1) as u32;
+
+    fn hash_calc(_: u32, val: u32) -> u32 {
+        const HASH_SLIDE: u32 = 16;
+        val.wrapping_mul(2654435761) >> HASH_SLIDE
+    }
+
+    pub fn update_hash(h: u32, val: u32) -> u32 {
         Self::hash_calc(h, val) & Self::HASH_CALC_MASK
     }
 
-    fn quick_insert_string(state: &mut State, string: usize) -> u16 {
+    pub fn quick_insert_string(state: &mut State, string: usize) -> u16 {
         let slice = &state.window.filled()[string + Self::HASH_CALC_OFFSET..];
         let val = u32::from_le_bytes(slice[..4].try_into().unwrap());
 
-        let hm = (Self::hash_calc(0, val) & Self::HASH_CALC_MASK) as usize;
+        let hm = Self::update_hash(0, val) as usize;
 
         let head = state.head[hm];
         if head != string as u16 {
@@ -52,7 +59,7 @@ pub trait HashCalc {
         head
     }
 
-    fn insert_string(state: &mut State, string: usize, count: usize) {
+    pub fn insert_string(state: &mut State, string: usize, count: usize) {
         let slice = &state.window.filled()[string + Self::HASH_CALC_OFFSET..];
 
         // .take(count) generates worse assembly
@@ -61,7 +68,7 @@ pub trait HashCalc {
 
             let val = u32::from_le_bytes(w.try_into().unwrap());
 
-            let hm = (Self::hash_calc(0, val) & Self::HASH_CALC_MASK) as usize;
+            let hm = Self::update_hash(0, val) as usize;
 
             let head = state.head[hm];
             if head != idx {
@@ -72,22 +79,9 @@ pub trait HashCalc {
     }
 }
 
-pub struct StandardHashCalc;
-
-impl HashCalc for StandardHashCalc {
-    const HASH_CALC_OFFSET: usize = 0;
-
-    const HASH_CALC_MASK: u32 = (HASH_SIZE - 1) as u32;
-
-    fn hash_calc(_: u32, val: u32) -> u32 {
-        const HASH_SLIDE: u32 = 16;
-        val.wrapping_mul(2654435761) >> HASH_SLIDE
-    }
-}
-
 pub struct RollHashCalc;
 
-impl HashCalc for RollHashCalc {
+impl RollHashCalc {
     const HASH_CALC_OFFSET: usize = STD_MIN_MATCH - 1;
 
     const HASH_CALC_MASK: u32 = (1 << 15) - 1;
@@ -97,7 +91,11 @@ impl HashCalc for RollHashCalc {
         (h << HASH_SLIDE) ^ val
     }
 
-    fn quick_insert_string(state: &mut State, string: usize) -> u16 {
+    pub fn update_hash(h: u32, val: u32) -> u32 {
+        Self::hash_calc(h, val) & Self::HASH_CALC_MASK
+    }
+
+    pub fn quick_insert_string(state: &mut State, string: usize) -> u16 {
         let val = state.window.filled()[string + Self::HASH_CALC_OFFSET] as u32;
 
         state.ins_h = Self::hash_calc(state.ins_h as u32, val) as usize;
@@ -114,7 +112,7 @@ impl HashCalc for RollHashCalc {
         head
     }
 
-    fn insert_string(state: &mut State, string: usize, count: usize) {
+    pub fn insert_string(state: &mut State, string: usize, count: usize) {
         let slice = &state.window.filled()[string + Self::HASH_CALC_OFFSET..][..count];
 
         for (i, val) in slice.iter().copied().enumerate() {
@@ -136,7 +134,7 @@ impl HashCalc for RollHashCalc {
 pub struct Crc32HashCalc;
 
 impl Crc32HashCalc {
-    pub fn is_supported() -> bool {
+    fn is_supported() -> bool {
         #[cfg(all(any(target_arch = "x86", target_arch = "x86_64"), feature = "std"))]
         return std::arch::is_x86_feature_detected!("sse4.2");
 
@@ -147,32 +145,80 @@ impl Crc32HashCalc {
         #[allow(unreachable_code)]
         false
     }
-}
 
-impl HashCalc for Crc32HashCalc {
     const HASH_CALC_OFFSET: usize = 0;
 
     const HASH_CALC_MASK: u32 = (HASH_SIZE - 1) as u32;
 
     #[cfg(target_arch = "x86")]
-    fn hash_calc(h: u32, val: u32) -> u32 {
+    #[target_feature(enable = "sse4.2")]
+    unsafe fn hash_calc(h: u32, val: u32) -> u32 {
         unsafe { core::arch::x86::_mm_crc32_u32(h, val) }
     }
 
     #[cfg(target_arch = "x86_64")]
-    fn hash_calc(h: u32, val: u32) -> u32 {
+    #[target_feature(enable = "sse4.2")]
+    unsafe fn hash_calc(h: u32, val: u32) -> u32 {
         unsafe { core::arch::x86_64::_mm_crc32_u32(h, val) }
     }
 
     #[cfg(target_arch = "aarch64")]
-    fn hash_calc(h: u32, val: u32) -> u32 {
+    #[target_feature(enable = "neon")]
+    unsafe fn hash_calc(h: u32, val: u32) -> u32 {
         unsafe { crate::crc32::acle::__crc32w(h, val) }
     }
 
     #[cfg(not(any(target_arch = "x86", target_arch = "x86_64", target_arch = "aarch64")))]
-    fn hash_calc(_h: u32, _val: u32) -> u32 {
+    unsafe fn hash_calc(_h: u32, _val: u32) -> u32 {
         assert!(!Self::is_supported());
         unimplemented!("there is no hardware support on this platform")
+    }
+
+    #[cfg_attr(target_arch = "aarch64", target_feature(enable = "neon"))]
+    #[cfg_attr(target_arch = "x86", target_feature(enable = "sse4.2"))]
+    #[cfg_attr(target_arch = "x86_64", target_feature(enable = "sse4.2"))]
+    pub unsafe fn update_hash(h: u32, val: u32) -> u32 {
+        (unsafe { Self::hash_calc(h, val) }) & Self::HASH_CALC_MASK
+    }
+
+    #[cfg_attr(target_arch = "aarch64", target_feature(enable = "neon"))]
+    #[cfg_attr(target_arch = "x86", target_feature(enable = "sse4.2"))]
+    #[cfg_attr(target_arch = "x86_64", target_feature(enable = "sse4.2"))]
+    pub unsafe fn quick_insert_string(state: &mut State, string: usize) -> u16 {
+        let slice = &state.window.filled()[string + Self::HASH_CALC_OFFSET..];
+        let val = u32::from_le_bytes(slice[..4].try_into().unwrap());
+
+        let hm = unsafe { Self::update_hash(0, val) } as usize;
+
+        let head = state.head[hm];
+        if head != string as u16 {
+            state.prev[string & state.w_mask] = head;
+            state.head[hm] = string as u16;
+        }
+
+        head
+    }
+
+    #[cfg_attr(target_arch = "aarch64", target_feature(enable = "neon"))]
+    #[cfg_attr(target_arch = "x86", target_feature(enable = "sse4.2"))]
+    #[cfg_attr(target_arch = "x86_64", target_feature(enable = "sse4.2"))]
+    pub unsafe fn insert_string(state: &mut State, string: usize, count: usize) {
+        let slice = &state.window.filled()[string + Self::HASH_CALC_OFFSET..];
+
+        // .take(count) generates worse assembly
+        for (i, w) in slice[..count + 3].windows(4).enumerate() {
+            let idx = string as u16 + i as u16;
+
+            let val = u32::from_le_bytes(w.try_into().unwrap());
+
+            let hm = unsafe { Self::update_hash(0, val) } as usize;
+
+            let head = state.head[hm];
+            if head != idx {
+                state.prev[idx as usize & state.w_mask] = head;
+                state.head[hm] = idx;
+            }
+        }
     }
 }
 
@@ -190,33 +236,35 @@ mod tests {
             return;
         }
 
-        if cfg!(target_arch = "x86") || cfg!(target_arch = "x86_64") {
-            assert_eq!(Crc32HashCalc::hash_calc(0, 807411760), 2423125009);
-            assert_eq!(Crc32HashCalc::hash_calc(0, 540024864), 1452438466);
-            assert_eq!(Crc32HashCalc::hash_calc(0, 538980384), 435552201);
-            assert_eq!(Crc32HashCalc::hash_calc(0, 807411760), 2423125009);
-            assert_eq!(Crc32HashCalc::hash_calc(0, 540024864), 1452438466);
-            assert_eq!(Crc32HashCalc::hash_calc(0, 538980384), 435552201);
-            assert_eq!(Crc32HashCalc::hash_calc(0, 807411760), 2423125009);
-            assert_eq!(Crc32HashCalc::hash_calc(0, 540024864), 1452438466);
-            assert_eq!(Crc32HashCalc::hash_calc(0, 538980384), 435552201);
-            assert_eq!(Crc32HashCalc::hash_calc(0, 807411760), 2423125009);
-            assert_eq!(Crc32HashCalc::hash_calc(0, 540024864), 1452438466);
-            assert_eq!(Crc32HashCalc::hash_calc(0, 538980384), 435552201);
-            assert_eq!(Crc32HashCalc::hash_calc(0, 807411760), 2423125009);
-            assert_eq!(Crc32HashCalc::hash_calc(0, 170926112), 500028708);
-            assert_eq!(Crc32HashCalc::hash_calc(0, 537538592), 3694129053);
-            assert_eq!(Crc32HashCalc::hash_calc(0, 538970672), 373925026);
-            assert_eq!(Crc32HashCalc::hash_calc(0, 538976266), 4149335727);
-            assert_eq!(Crc32HashCalc::hash_calc(0, 538976288), 1767342659);
-            assert_eq!(Crc32HashCalc::hash_calc(0, 941629472), 4090502627);
-            assert_eq!(Crc32HashCalc::hash_calc(0, 775430176), 1744703325);
-        } else {
-            assert_eq!(Crc32HashCalc::hash_calc(0, 807411760), 2067507791);
-            assert_eq!(Crc32HashCalc::hash_calc(0, 540024864), 2086141925);
-            assert_eq!(Crc32HashCalc::hash_calc(0, 538980384), 716394180);
-            assert_eq!(Crc32HashCalc::hash_calc(0, 775430176), 1396070634);
-            assert_eq!(Crc32HashCalc::hash_calc(0, 941629472), 637105634);
+        unsafe {
+            if cfg!(target_arch = "x86") || cfg!(target_arch = "x86_64") {
+                assert_eq!(Crc32HashCalc::hash_calc(0, 807411760), 2423125009);
+                assert_eq!(Crc32HashCalc::hash_calc(0, 540024864), 1452438466);
+                assert_eq!(Crc32HashCalc::hash_calc(0, 538980384), 435552201);
+                assert_eq!(Crc32HashCalc::hash_calc(0, 807411760), 2423125009);
+                assert_eq!(Crc32HashCalc::hash_calc(0, 540024864), 1452438466);
+                assert_eq!(Crc32HashCalc::hash_calc(0, 538980384), 435552201);
+                assert_eq!(Crc32HashCalc::hash_calc(0, 807411760), 2423125009);
+                assert_eq!(Crc32HashCalc::hash_calc(0, 540024864), 1452438466);
+                assert_eq!(Crc32HashCalc::hash_calc(0, 538980384), 435552201);
+                assert_eq!(Crc32HashCalc::hash_calc(0, 807411760), 2423125009);
+                assert_eq!(Crc32HashCalc::hash_calc(0, 540024864), 1452438466);
+                assert_eq!(Crc32HashCalc::hash_calc(0, 538980384), 435552201);
+                assert_eq!(Crc32HashCalc::hash_calc(0, 807411760), 2423125009);
+                assert_eq!(Crc32HashCalc::hash_calc(0, 170926112), 500028708);
+                assert_eq!(Crc32HashCalc::hash_calc(0, 537538592), 3694129053);
+                assert_eq!(Crc32HashCalc::hash_calc(0, 538970672), 373925026);
+                assert_eq!(Crc32HashCalc::hash_calc(0, 538976266), 4149335727);
+                assert_eq!(Crc32HashCalc::hash_calc(0, 538976288), 1767342659);
+                assert_eq!(Crc32HashCalc::hash_calc(0, 941629472), 4090502627);
+                assert_eq!(Crc32HashCalc::hash_calc(0, 775430176), 1744703325);
+            } else {
+                assert_eq!(Crc32HashCalc::hash_calc(0, 807411760), 2067507791);
+                assert_eq!(Crc32HashCalc::hash_calc(0, 540024864), 2086141925);
+                assert_eq!(Crc32HashCalc::hash_calc(0, 538980384), 716394180);
+                assert_eq!(Crc32HashCalc::hash_calc(0, 775430176), 1396070634);
+                assert_eq!(Crc32HashCalc::hash_calc(0, 941629472), 637105634);
+            }
         }
     }
 


### PR DESCRIPTION
```
Benchmark 1 (57 runs): ./target/release/examples/baseline 1 rs silesia-small.tar
  measurement          mean ± σ            min … max           outliers         delta
  wall_time          87.6ms ±  945us    86.0ms … 91.1ms          3 ( 5%)        0%
  peak_rss           26.6MB ± 61.5KB    26.5MB … 26.6MB          0 ( 0%)        0%
  cpu_cycles          330M  ± 2.86M      323M  …  341M           3 ( 5%)        0%
  instructions        776M  ±  249       776M  …  776M           0 ( 0%)        0%
  cache_references   19.9M  ±  188K     19.6M  … 20.5M           3 ( 5%)        0%
  cache_misses        478K  ± 96.6K      362K  …  828K           5 ( 9%)        0%
  branch_misses      3.06M  ± 1.21K     3.06M  … 3.07M           1 ( 2%)        0%
Benchmark 2 (58 runs): ./target/release/examples/blogpost-compress 1 rs silesia-small.tar
  measurement          mean ± σ            min … max           outliers         delta
  wall_time          86.7ms ±  915us    85.0ms … 91.4ms          4 ( 7%)          -  1.0% ±  0.4%
  peak_rss           26.5MB ± 65.8KB    26.5MB … 26.6MB          0 ( 0%)          -  0.1% ±  0.1%
  cpu_cycles          326M  ± 3.53M      320M  …  340M           5 ( 9%)          -  1.1% ±  0.4%
  instructions        718M  ±  288       718M  …  718M           0 ( 0%)        ⚡-  7.4% ±  0.0%
  cache_references   19.8M  ±  191K     19.5M  … 20.4M           5 ( 9%)          -  0.2% ±  0.4%
  cache_misses        434K  ±  105K      323K  …  968K           6 (10%)        ⚡-  9.1% ±  7.8%
  branch_misses      3.07M  ± 18.1K     3.05M  … 3.10M           0 ( 0%)          +  0.0% ±  0.2%
```