### PR TITLE
Extend from window

### DIFF
--- a/test-libz-rs-sys/examples/blogpost-uncompress.rs
+++ b/test-libz-rs-sys/examples/blogpost-uncompress.rs
@@ -66,6 +66,8 @@ fn main() {
     let mut dest_len = dest_vec.len() as std::ffi::c_ulong;
     let dest = dest_vec.as_mut_ptr();
 
+    let silesia_small_tar_gz = include_bytes!("../../silesia-small.tar.gz");
+
     match it.next().unwrap().as_str() {
         "ng" => {
             let path = it.next().unwrap();
@@ -90,18 +92,22 @@ fn main() {
         "ng-chunked" => {
             let chunk_log: usize = it.next().unwrap().parse().unwrap();
 
-            let path = it.next().unwrap();
-            let input = std::fs::read(&path).unwrap();
-
-            let _ = chunked!("chunked-ng", 1 << chunk_log, &mut dest_vec, &input);
+            let _ = chunked!(
+                "chunked-ng",
+                1 << chunk_log,
+                &mut dest_vec,
+                &silesia_small_tar_gz
+            );
         }
         "rs-chunked" => {
             let chunk_log: usize = it.next().unwrap().parse().unwrap();
 
-            let path = it.next().unwrap();
-            let input = std::fs::read(&path).unwrap();
-
-            let _ = chunked!("chunked-rs", 1 << chunk_log, &mut dest_vec, &input);
+            let _ = chunked!(
+                "chunked-rs",
+                1 << chunk_log,
+                &mut dest_vec,
+                &silesia_small_tar_gz
+            );
         }
         "ng-adler" => {
             let chunk_log: usize = it.next().unwrap().parse().unwrap();

--- a/zlib-rs/src/inflate.rs
+++ b/zlib-rs/src/inflate.rs
@@ -1685,7 +1685,7 @@ fn inflate_fast_help(state: &mut State, _start: usize) -> ReturnCode {
                             }
 
                             let copy = Ord::min(op, len as usize);
-                            writer.extend(&state.window.as_slice()[from..][..copy]);
+                            writer.extend_from_window(&state.window, from..from + copy);
 
                             if op < len as usize {
                                 // here we need some bytes from the output itself

--- a/zlib-rs/src/inflate.rs
+++ b/zlib-rs/src/inflate.rs
@@ -1281,7 +1281,8 @@ impl<'a> State<'a> {
             copy = Ord::min(copy, self.length);
             copy = Ord::min(copy, left);
 
-            self.writer.extend(&self.window.as_slice()[from..][..copy]);
+            self.writer
+                .extend_from_window(&self.window, from..from + copy);
 
             copy
         } else {
@@ -1678,7 +1679,7 @@ fn inflate_fast_help(state: &mut State, _start: usize) -> ReturnCode {
                                     // window, and part of it has wrapped around to the start. Copy
                                     // the end section here, the start section will be copied below.
                                     len -= op as u16;
-                                    writer.extend(&state.window.as_slice()[from..][..op]);
+                                    writer.extend_from_window(&state.window, from..from + op);
                                     from = 0;
                                     op = window_next;
                                 }

--- a/zlib-rs/src/inflate/window.rs
+++ b/zlib-rs/src/inflate/window.rs
@@ -66,6 +66,10 @@ impl<'a> Window<'a> {
         unsafe { slice_assume_init(&self.buf[..self.have]) }
     }
 
+    pub fn as_ptr(&self) -> *const MaybeUninit<u8> {
+        self.buf.as_ptr()
+    }
+
     #[cfg(test)]
     fn extend_adler32(&mut self, slice: &[u8], checksum: &mut u32) {
         self.extend(slice, 0, true, checksum, &mut Crc32Fold::new());

--- a/zlib-rs/src/inflate/writer.rs
+++ b/zlib-rs/src/inflate/writer.rs
@@ -92,7 +92,7 @@ impl<'a> Writer<'a> {
         range: Range<usize>,
     ) {
         let len = range.end - range.start;
-        if self.remaining() >= 32 {
+        if self.remaining() >= core::mem::size_of::<C>() {
             // Safety: we know that our window has at least a core::mem::size_of::<C>() extra bytes
             // at the end, making it always safe to perform an (unaligned) Chunk read anywhere in
             // the window slice.

--- a/zlib-rs/src/inflate/writer.rs
+++ b/zlib-rs/src/inflate/writer.rs
@@ -1,5 +1,6 @@
 use core::fmt;
 use core::mem::MaybeUninit;
+use core::ops::Range;
 
 pub struct Writer<'a> {
     buf: &'a mut [MaybeUninit<u8>],
@@ -62,6 +63,53 @@ impl<'a> Writer<'a> {
         self.buf[self.filled..][..buf.len()].copy_from_slice(slice_to_uninit(buf));
 
         self.filled += buf.len();
+    }
+
+    #[inline(always)]
+    pub fn extend_from_window(&mut self, window: &super::window::Window, range: Range<usize>) {
+        #[cfg(target_arch = "x86_64")]
+        if crate::cpu_features::is_enabled_avx512() {
+            return self.extend_from_window_help::<core::arch::x86_64::__m512i>(window, range);
+        }
+
+        #[cfg(target_arch = "x86_64")]
+        if crate::cpu_features::is_enabled_avx2() {
+            return self.extend_from_window_help::<core::arch::x86_64::__m256i>(window, range);
+        }
+
+        #[cfg(target_arch = "x86_64")]
+        if crate::cpu_features::is_enabled_sse() {
+            return self.extend_from_window_help::<core::arch::x86_64::__m128i>(window, range);
+        }
+
+        self.extend_from_window_help::<u64>(window, range)
+    }
+
+    #[inline(always)]
+    fn extend_from_window_help<C: Chunk>(
+        &mut self,
+        window: &super::window::Window,
+        range: Range<usize>,
+    ) {
+        let len = range.end - range.start;
+        if self.remaining() >= 32 {
+            // Safety: we know that our window has at least a core::mem::size_of::<C>() extra bytes
+            // at the end, making it always safe to perform an (unaligned) Chunk read anywhere in
+            // the window slice.
+            unsafe {
+                let src = window.as_ptr();
+                Self::copy_chunk_unchecked::<C>(
+                    src.wrapping_add(range.start),
+                    self.next_out(),
+                    src.wrapping_add(range.end),
+                )
+            }
+        } else {
+            let buf = &window.as_slice()[range];
+            self.buf[self.filled..][..buf.len()].copy_from_slice(slice_to_uninit(buf));
+        }
+
+        self.filled += len;
     }
 
     #[inline(always)]


### PR DESCRIPTION
```
Benchmark 1 (97 runs): ./uncompress-baseline rs-chunked 7 silesia-small.tar.gz
  measurement          mean ± σ            min … max           outliers         delta
  wall_time          51.8ms ± 2.71ms    50.6ms … 72.1ms          5 ( 5%)        0%
  peak_rss           24.1MB ± 65.6KB    23.9MB … 24.1MB          0 ( 0%)        0%
  cpu_cycles          195M  ± 8.35M      192M  …  252M           9 ( 9%)        0%
  instructions        537M  ±  372       537M  …  537M           1 ( 1%)        0%
  cache_references   2.77M  ±  298K     2.49M  … 4.67M           4 ( 4%)        0%
  cache_misses        157K  ± 32.8K      112K  …  295K           3 ( 3%)        0%
  branch_misses      2.46M  ± 4.82K     2.46M  … 2.49M           7 ( 7%)        0%
Benchmark 2 (107 runs): target/release/examples/blogpost-uncompress rs-chunked 7 silesia-small.tar.gz
  measurement          mean ± σ            min … max           outliers         delta
  wall_time          46.7ms ±  854us    45.6ms … 53.2ms          6 ( 6%)        ⚡-  9.9% ±  1.0%
  peak_rss           24.1MB ± 66.8KB    23.9MB … 24.1MB          0 ( 0%)          +  0.0% ±  0.1%
  cpu_cycles          174M  ± 3.15M      172M  …  199M          15 (14%)        ⚡- 10.8% ±  0.9%
  instructions        500M  ±  259       500M  …  500M           0 ( 0%)        ⚡-  6.9% ±  0.0%
  cache_references   3.05M  ±  204K     2.81M  … 4.39M           5 ( 5%)        💩+  9.9% ±  2.5%
  cache_misses       51.8K  ± 15.6K     35.2K  …  174K           4 ( 4%)        ⚡- 67.1% ±  4.4%
  branch_misses      2.03M  ± 1.71K     2.03M  … 2.04M           3 ( 3%)        ⚡- 17.4% ±  0.0%
```