### PR TITLE
remove adler32 COPY variant (memcpy is faster)

### DIFF
--- a/zlib-rs/src/adler32.rs
+++ b/zlib-rs/src/adler32.rs
@@ -23,14 +23,10 @@ pub fn adler32(start_checksum: u32, data: &[u8]) -> u32 {
 pub fn adler32_fold_copy(start_checksum: u32, dst: &mut [MaybeUninit<u8>], src: &[u8]) -> u32 {
     debug_assert!(dst.len() >= src.len(), "{} < {}", dst.len(), src.len());
 
-    #[cfg(target_arch = "x86_64")]
-    if crate::cpu_features::is_enabled_avx2() {
-        return avx2::adler32_fold_copy_avx2(start_checksum, dst, src);
-    }
-
-    let adler = adler32(start_checksum, src);
+    // integrating the memcpy into the adler32 function did not have any benefits, and in fact was
+    // a bit slower for very small chunk sizes.
     dst[..src.len()].copy_from_slice(slice_to_uninit(src));
-    adler
+    adler32(start_checksum, src)
 }
 
 pub fn adler32_combine(adler1: u32, adler2: u32, len2: u64) -> u32 {

--- a/zlib-rs/src/adler32/generic.rs
+++ b/zlib-rs/src/adler32/generic.rs
@@ -1,5 +1,3 @@
-use core::mem::MaybeUninit;
-
 use super::{BASE, NMAX};
 
 const UNROLL_MORE: bool = true;
@@ -91,26 +89,6 @@ pub(crate) fn adler32_len_1(mut adler: u32, buf: &[u8], mut sum2: u32) -> u32 {
 pub(crate) fn adler32_len_16(mut adler: u32, buf: &[u8], mut sum2: u32) -> u32 {
     for b in buf {
         adler += (*b) as u32;
-        sum2 += adler;
-    }
-
-    adler %= BASE;
-    sum2 %= BASE; /* only added so many BASE's */
-    /* return recombined sums */
-    adler | (sum2 << 16)
-}
-
-#[cfg_attr(not(target_arch = "x86_64"), allow(unused))]
-pub(crate) fn adler32_copy_len_16(
-    mut adler: u32,
-    dst: &mut [MaybeUninit<u8>],
-    src: &[u8],
-    mut sum2: u32,
-) -> u32 {
-    for (source, destination) in src.iter().zip(dst.iter_mut()) {
-        let v = *source;
-        *destination = MaybeUninit::new(v);
-        adler += v as u32;
         sum2 += adler;
     }
 


### PR DESCRIPTION
for small chunk sizes anyway, for larger ones it does not matter, but the code without the copy is a lot simpler.

```
Benchmark 1 (85 runs): target/release/examples/uncompress-baseline rs-chunked 5 silesia-small.tar.gz
  measurement          mean ± σ            min … max           outliers         delta
  wall_time          58.8ms ±  505us    58.0ms … 60.8ms          3 ( 4%)        0%
  peak_rss           24.1MB ± 70.3KB    23.9MB … 24.1MB          0 ( 0%)        0%
  cpu_cycles          232M  ± 1.66M      230M  …  242M           7 ( 8%)        0%
  instructions        677M  ±  245       677M  …  677M           1 ( 1%)        0%
  cache_references   3.11M  ±  403K     2.91M  … 6.74M           1 ( 1%)        0%
  cache_misses        120K  ± 10.7K      107K  …  172K           5 ( 6%)        0%
  branch_misses      3.23M  ± 10.2K     3.21M  … 3.27M           1 ( 1%)        0%
Benchmark 2 (87 runs): target/release/examples/blogpost-uncompress rs-chunked 5 silesia-small.tar.gz
  measurement          mean ± σ            min … max           outliers         delta
  wall_time          57.7ms ±  934us    56.9ms … 64.1ms          4 ( 5%)        ⚡-  1.9% ±  0.4%
  peak_rss           24.1MB ± 64.2KB    23.9MB … 24.1MB          0 ( 0%)          +  0.0% ±  0.1%
  cpu_cycles          226M  ± 3.72M      225M  …  253M           5 ( 6%)        ⚡-  2.2% ±  0.4%
  instructions        672M  ±  289       672M  …  672M           0 ( 0%)          -  0.8% ±  0.0%
  cache_references   3.13M  ±  116K     2.87M  … 3.95M           2 ( 2%)          +  0.6% ±  2.8%
  cache_misses        146K  ± 14.8K      123K  …  211K           3 ( 3%)        💩+ 21.7% ±  3.2%
  branch_misses      3.10M  ± 6.17K     3.10M  … 3.15M           2 ( 2%)        ⚡-  4.0% ±  0.1%
Benchmark 1 (111 runs): target/release/examples/uncompress-baseline rs-chunked 7 silesia-small.tar.gz
  measurement          mean ± σ            min … max           outliers         delta
  wall_time          45.0ms ± 1.71ms    43.9ms … 62.3ms          5 ( 5%)        0%
  peak_rss           24.1MB ± 67.3KB    23.9MB … 24.1MB          0 ( 0%)        0%
  cpu_cycles          169M  ± 6.37M      167M  …  234M          13 (12%)        0%
  instructions        502M  ±  261       502M  …  502M           0 ( 0%)        0%
  cache_references   3.14M  ±  375K     2.88M  … 6.47M           5 ( 5%)        0%
  cache_misses        125K  ± 33.2K      108K  …  369K           5 ( 5%)        0%
  branch_misses      1.98M  ± 6.39K     1.98M  … 2.01M          10 ( 9%)        0%
Benchmark 2 (112 runs): target/release/examples/blogpost-uncompress rs-chunked 7 silesia-small.tar.gz
  measurement          mean ± σ            min … max           outliers         delta
  wall_time          44.9ms ±  458us    44.0ms … 46.4ms          7 ( 6%)          -  0.2% ±  0.7%
  peak_rss           24.1MB ± 68.1KB    23.9MB … 24.1MB          0 ( 0%)          -  0.0% ±  0.1%
  cpu_cycles          168M  ± 1.16M      167M  …  175M          14 (13%)          -  0.3% ±  0.7%
  instructions        500M  ±  237       500M  …  500M           0 ( 0%)          -  0.3% ±  0.0%
  cache_references   3.18M  ±  153K     2.94M  … 4.52M           2 ( 2%)          +  1.2% ±  2.4%
  cache_misses        113K  ± 5.27K     98.8K  …  132K           8 ( 7%)        ⚡-  9.2% ±  5.0%
  branch_misses      2.00M  ± 1.63K     1.99M  … 2.00M           1 ( 1%)          +  0.7% ±  0.1%
```