### PR TITLE
remove `libz-sys` dependency from `zlib-rs` crate

### DIFF
--- a/zlib-rs/Cargo.toml
+++ b/zlib-rs/Cargo.toml
@@ -24,7 +24,6 @@ ZLIB_DEBUG = []
 
 [dependencies]
 arbitrary = { workspace = true, optional = true, features = ["derive"] }
-libz-sys = { workspace = true, optional = true }
 quickcheck = { workspace = true, optional = true }
 
 [dev-dependencies]


### PR DESCRIPTION
cc @inahga this was indeed unused (after some refactoring a while ago)