### PR TITLE
wasm: allow unaligned reads in `longest_match`

### DIFF
--- a/zlib-rs/src/deflate/longest_match.rs
+++ b/zlib-rs/src/deflate/longest_match.rs
@@ -5,6 +5,7 @@ type Pos = u16;
 const EARLY_EXIT_TRIGGER_LEVEL: i8 = 5;
 
 const UNALIGNED_OK: bool = cfg!(any(
+    target_arch = "wasm32",
     target_arch = "x86",
     target_arch = "x86_64",
     target_arch = "arm",
@@ -13,6 +14,7 @@ const UNALIGNED_OK: bool = cfg!(any(
 ));
 
 const UNALIGNED64_OK: bool = cfg!(any(
+    target_arch = "wasm32",
     target_arch = "x86_64",
     target_arch = "aarch64",
     target_arch = "powerpc64",


### PR DESCRIPTION
a small win

```
Benchmark 1 (8 runs): wasmtime baseline.wasm deflate zlib-rs
  measurement          mean ± σ            min … max           outliers         delta
  wall_time           657ms ± 3.80ms     653ms …  664ms          0 ( 0%)        0%
  peak_rss           82.2MB ± 2.19KB    82.1MB … 82.2MB          0 ( 0%)        0%
  cpu_cycles         2.76G  ± 14.9M     2.75G  … 2.80G           1 (13%)        0%
  instructions       8.23G  ± 2.12K     8.23G  … 8.23G           0 ( 0%)        0%
  cache_references    204M  ± 1.15M      202M  …  206M           0 ( 0%)        0%
  cache_misses       3.35M  ±  714K     2.27M  … 4.27M           0 ( 0%)        0%
  branch_misses      21.7M  ± 13.6K     21.7M  … 21.7M           0 ( 0%)        0%
Benchmark 2 (8 runs): wasmtime target/wasm32-wasi/release/wasm-zlib-benchmark.wasm deflate zlib-rs
  measurement          mean ± σ            min … max           outliers         delta
  wall_time           638ms ±  975us     637ms …  640ms          0 ( 0%)        ⚡-  2.8% ±  0.5%
  peak_rss           82.2MB ±    0      82.2MB … 82.2MB          0 ( 0%)          +  0.0% ±  0.0%
  cpu_cycles         2.68G  ± 5.60M     2.68G  … 2.70G           1 (13%)        ⚡-  2.9% ±  0.4%
  instructions       7.28G  ±  478      7.28G  … 7.28G           0 ( 0%)        ⚡- 11.5% ±  0.0%
  cache_references    204M  ± 1.35M      202M  …  206M           0 ( 0%)          +  0.1% ±  0.7%
  cache_misses       3.35M  ± 1.03M     2.07M  … 4.62M           0 ( 0%)          +  0.1% ± 28.4%
  branch_misses      19.4M  ± 7.25K     19.4M  … 19.4M           2 (25%)        ⚡- 10.8% ±  0.1%
```