### PR TITLE
fix UB in `inflate::State::extra`

### DIFF
--- a/test-libz-rs-sys/src/inflate.rs
+++ b/test-libz-rs-sys/src/inflate.rs
@@ -1206,6 +1206,21 @@ fn gzip_chunked_2_bytes() {
 }
 
 #[test]
+fn gzip_chunked_15_bytes() {
+    gzip_chunked(15);
+}
+
+#[test]
+fn gzip_chunked_16_bytes() {
+    gzip_chunked(16);
+}
+
+#[test]
+fn gzip_chunked_17_bytes() {
+    gzip_chunked(17);
+}
+
+#[test]
 fn gzip_chunked_32_bytes() {
     gzip_chunked(32);
 }

--- a/test-libz-rs-sys/src/lib.rs
+++ b/test-libz-rs-sys/src/lib.rs
@@ -15,7 +15,7 @@ macro_rules! assert_eq_rs_ng {
         #[allow(clippy::macro_metavars_in_unsafe)]
         #[allow(unused_braces)]
         #[allow(unused_unsafe)]
-        let ng = unsafe {
+        let _ng = unsafe {
             use libz_sys::*;
 
             $tt
@@ -24,14 +24,14 @@ macro_rules! assert_eq_rs_ng {
         #[allow(clippy::macro_metavars_in_unsafe)]
         #[allow(unused_braces)]
         #[allow(unused_unsafe)]
-        let rs = unsafe {
+        let _rs = unsafe {
             use libz_rs_sys::*;
 
             $tt
         };
 
         #[cfg(not(miri))]
-        assert_eq!(rs, ng);
+        assert_eq!(_rs, _ng);
     };
 }
 


### PR DESCRIPTION
fixes https://github.com/memorysafety/zlib-rs/issues/195

I think this is a bit more elegant than a check for `count > 0`. 

Extra is a bit different because it has both a `extra_len` and `extra_max` field, so using the name/comment logic does not work.

cc @inahga