### PR TITLE
Reenable deflate::test::insufficient_compress_space under Miri

### DIFF
--- a/zlib-rs/src/deflate.rs
+++ b/zlib-rs/src/deflate.rs
@@ -3842,7 +3842,6 @@ mod test {
     }
 
     #[test]
-    #[cfg_attr(miri, ignore)]
     fn insufficient_compress_space() {
         const DATA: &[u8] = include_bytes!("deflate/test-data/inflate_buf_error.dat");
 


### PR DESCRIPTION
This test passes under Miri. This includes under s390x, [as the original PR that introduced it was making fixes for](https://github.com/memorysafety/zlib-rs/pull/138). So I see no reason to disable it. Maybe it was a left over disable from development?